### PR TITLE
🔒 [security fix] Mark Capacities API credential as required

### DIFF
--- a/credentials/CapacitiesApi.credentials.ts
+++ b/credentials/CapacitiesApi.credentials.ts
@@ -1,5 +1,6 @@
 import {
-	IAuthenticateGeneric, Icon,
+	IAuthenticateGeneric,
+	Icon,
 	ICredentialTestRequest,
 	ICredentialType,
 	INodeProperties,

--- a/nodes/Capacities/Capacities.node.ts
+++ b/nodes/Capacities/Capacities.node.ts
@@ -1,4 +1,4 @@
-import type {INodeType, INodeTypeDescription} from 'n8n-workflow';
+import type { INodeType, INodeTypeDescription } from 'n8n-workflow';
 import { resources } from './ResourceDescription';
 import { general } from './GeneralDescription';
 import { space } from './SpaceDescription';
@@ -32,7 +32,7 @@ export class Capacities implements INodeType {
 		credentials: [
 			{
 				name: 'capacitiesApi',
-				required: false,
+				required: true,
 			},
 		],
 		requestDefaults: {
@@ -43,13 +43,6 @@ export class Capacities implements INodeType {
 				'Content-Type': 'application/json',
 			},
 		},
-		properties: [
-			...resources,
-			...space,
-			...search,
-			...weblink,
-			...dailyNote,
-			...general,
-		],
+		properties: [...resources, ...space, ...search, ...weblink, ...dailyNote, ...general],
 	};
 }

--- a/nodes/Capacities/DailyNoteDescription.ts
+++ b/nodes/Capacities/DailyNoteDescription.ts
@@ -1,5 +1,5 @@
-import type  { INodeProperties } from 'n8n-workflow';
-import {loadSpaces} from "./GeneralFunctions";
+import type { INodeProperties } from 'n8n-workflow';
+import { loadSpaces } from './GeneralFunctions';
 
 export const dailyNote: INodeProperties[] = [
 	{
@@ -13,7 +13,7 @@ export const dailyNote: INodeProperties[] = [
 			{
 				name: 'Save',
 				value: 'saveToDailyNote',
-				description: 'Save text to today\'s daily note',
+				description: "Save text to today's daily note",
 				routing: {
 					request: {
 						url: '/save-to-daily-note',
@@ -28,13 +28,11 @@ export const dailyNote: INodeProperties[] = [
 					},
 				},
 				action: 'Save a daily note',
-			}
+			},
 		],
 		displayOptions: {
 			show: {
-				resource: [
-					'dailyNote',
-				],
+				resource: ['dailyNote'],
 			},
 		},
 	},
@@ -64,30 +62,22 @@ export const dailyNote: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: [
-					'dailyNote',
-				],
-				operation: [
-					'saveToDailyNote',
-				],
+				resource: ['dailyNote'],
+				operation: ['saveToDailyNote'],
 			},
 		},
 	},
 	{
-		displayName: "Timestamp",
-		name: "timestamp",
-		type: "boolean",
+		displayName: 'Timestamp',
+		name: 'timestamp',
+		type: 'boolean',
 		default: true,
-		description: "Whether to add a timestamp to the note",
+		description: 'Whether to add a timestamp to the note',
 		displayOptions: {
 			show: {
-				resource: [
-					'dailyNote',
-				],
-				operation: [
-					'saveToDailyNote',
-				],
+				resource: ['dailyNote'],
+				operation: ['saveToDailyNote'],
 			},
 		},
-	}
+	},
 ];

--- a/nodes/Capacities/GeneralDescription.ts
+++ b/nodes/Capacities/GeneralDescription.ts
@@ -1,5 +1,3 @@
-import type {INodeProperties} from "n8n-workflow";
+import type { INodeProperties } from 'n8n-workflow';
 
-export const general: INodeProperties[] = [
-
-];
+export const general: INodeProperties[] = [];

--- a/nodes/Capacities/GeneralFunctions.ts
+++ b/nodes/Capacities/GeneralFunctions.ts
@@ -29,8 +29,8 @@ export const loadSpaces: ILoadOptions = {
 					},
 				},
 			],
-		}
-	}
+		},
+	},
 };
 
 export async function loadStructures(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
@@ -111,7 +111,8 @@ export async function loadStructures(this: ILoadOptionsFunctions): Promise<INode
 
 			const structureName = typeof displayNameSource === 'string' ? displayNameSource : idValue;
 			const spaceLabel = formatSpaceContext(spaceId);
-			const nameWithContext = spaceIds.length > 1 ? `${structureName} (${spaceLabel})` : structureName;
+			const nameWithContext =
+				spaceIds.length > 1 ? `${structureName} (${spaceLabel})` : structureName;
 			if (!structureLabelById.has(idValue)) {
 				structureLabelById.set(idValue, nameWithContext);
 			}

--- a/nodes/Capacities/SearchDescription.ts
+++ b/nodes/Capacities/SearchDescription.ts
@@ -33,59 +33,48 @@ export const search: INodeProperties[] = [
 								},
 							},
 						],
-					}
+					},
 				},
 				action: 'Search',
 			},
 		],
 		displayOptions: {
 			show: {
-				resource: [
-					'search',
-				],
+				resource: ['search'],
 			},
 		},
 	},
 
 	{
-		displayName: "Search Term",
-		name: "searchTerm",
-		type: "string",
+		displayName: 'Search Term',
+		name: 'searchTerm',
+		type: 'string',
 		required: true,
-		default: "",
+		default: '',
 		description: 'The term to search for',
 		displayOptions: {
 			show: {
-				resource: [
-					'search',
-				],
-				operation: [
-					'search',
-				],
+				resource: ['search'],
+				operation: ['search'],
 			},
-		}
+		},
 	},
 	{
-		displayName: "Space",
-		name: "searchSpaceId",
-		type: "options",
+		displayName: 'Space',
+		name: 'searchSpaceId',
+		type: 'options',
 		typeOptions: {
 			emptyValue: 'Please select a space',
 			loadOptions: loadSpaces,
 		},
 		default: '',
-		placeholder: "Select a Space",
+		placeholder: 'Select a Space',
 		description: 'The ID of the space to search in. Leave empty to search all spaces.',
 		displayOptions: {
 			show: {
-				resource: [
-					'search',
-				],
-				operation: [
-					'search',
-				],
+				resource: ['search'],
+				operation: ['search'],
 			},
 		},
 	},
-
 ];

--- a/nodes/Capacities/WeblinkDescription.ts
+++ b/nodes/Capacities/WeblinkDescription.ts
@@ -1,5 +1,5 @@
 import type { INodeProperties } from 'n8n-workflow';
-import {loadSpaces} from "./GeneralFunctions";
+import { loadSpaces } from './GeneralFunctions';
 
 export const weblink: INodeProperties[] = [
 	{
@@ -24,14 +24,12 @@ export const weblink: INodeProperties[] = [
 							url: '={{$parameter.url}}',
 						},
 					},
-				}
+				},
 			},
 		],
 		displayOptions: {
 			show: {
-				resource: [
-					'weblink',
-				],
+				resource: ['weblink'],
 			},
 		},
 	},
@@ -44,12 +42,8 @@ export const weblink: INodeProperties[] = [
 		default: '',
 		displayOptions: {
 			show: {
-				resource: [
-					'weblink',
-				],
-				operation: [
-					'save',
-				],
+				resource: ['weblink'],
+				operation: ['save'],
 			},
 		},
 	},
@@ -64,12 +58,8 @@ export const weblink: INodeProperties[] = [
 		default: '',
 		displayOptions: {
 			show: {
-				resource: [
-					'weblink',
-				],
-				operation: [
-					'save',
-				],
+				resource: ['weblink'],
+				operation: ['save'],
 			},
 		},
 	},
@@ -92,9 +82,9 @@ export const weblink: INodeProperties[] = [
 					request: {
 						body: {
 							mdText: '={{$value}}',
-						}
-					}
-				}
+						},
+					},
+				},
 			},
 			{
 				displayName: 'Title Overwrite',
@@ -107,9 +97,9 @@ export const weblink: INodeProperties[] = [
 					request: {
 						body: {
 							titleOverwrite: '={{$value}}',
-						}
-					}
-				}
+						},
+					},
+				},
 			},
 			{
 				displayName: 'Description Overwrite',
@@ -122,9 +112,9 @@ export const weblink: INodeProperties[] = [
 					request: {
 						body: {
 							descriptionOverwrite: '={{$value}}',
-						}
-					}
-				}
+						},
+					},
+				},
 			},
 			{
 				displayName: 'Tags',
@@ -140,19 +130,15 @@ export const weblink: INodeProperties[] = [
 					request: {
 						body: {
 							tags: '={{$value}}',
-						}
-					}
-				}
+						},
+					},
+				},
 			},
 		],
 		displayOptions: {
 			show: {
-				resource: [
-					'weblink',
-				],
-				operation: [
-					'save',
-				],
+				resource: ['weblink'],
+				operation: ['save'],
 			},
 		},
 	},

--- a/nodes/Capacities/__tests__/Capacities.node.test.ts
+++ b/nodes/Capacities/__tests__/Capacities.node.test.ts
@@ -17,16 +17,23 @@ describe('Capacities node', () => {
 		const node = new Capacities();
 		const resourceProperty = getProperty(node.description.properties, 'resource');
 		expect(resourceProperty?.type).toBe('options');
-		expect(getOptions(resourceProperty).map((option) => option.value).sort()).toEqual([
-			'dailyNote',
-			'search',
-			'space',
-			'weblink',
-		]);
+		expect(
+			getOptions(resourceProperty)
+				.map((option) => option.value)
+				.sort(),
+		).toEqual(['dailyNote', 'search', 'space', 'weblink']);
 	});
 
 	it('registers loadStructures helper for load options', () => {
 		const node = new Capacities();
 		expect(node.methods.loadOptions.loadStructures).toBeDefined();
+	});
+
+	it('requires capacitiesApi credentials', () => {
+		const node = new Capacities();
+		expect(node.description.credentials).toContainEqual({
+			name: 'capacitiesApi',
+			required: true,
+		});
 	});
 });

--- a/nodes/Capacities/__tests__/DailyNoteDescription.test.ts
+++ b/nodes/Capacities/__tests__/DailyNoteDescription.test.ts
@@ -6,7 +6,9 @@ describe('DailyNote description', () => {
 	it('provides save operation wired to POST /save-to-daily-note', () => {
 		const operationProperty = getProperty(dailyNote, 'operation', 'dailyNote');
 		expect(operationProperty).toBeDefined();
-		const saveOption = getOptions(operationProperty).find((option) => option.value === 'saveToDailyNote');
+		const saveOption = getOptions(operationProperty).find(
+			(option) => option.value === 'saveToDailyNote',
+		);
 		expect(saveOption?.routing?.request).toMatchObject({
 			url: '/save-to-daily-note',
 			method: 'POST',

--- a/nodes/Capacities/__tests__/GeneralFunctions.test.ts
+++ b/nodes/Capacities/__tests__/GeneralFunctions.test.ts
@@ -45,7 +45,7 @@ describe('loadSpaces descriptor', () => {
 				}),
 				expect.objectContaining({ type: 'setKeyValue' }),
 				expect.objectContaining({ type: 'sort' }),
-		]),
+			]),
 		);
 	});
 });
@@ -56,7 +56,10 @@ describe('loadStructures helper', () => {
 	});
 
 	it('returns an empty list without hitting the API when no space is selected', async () => {
-		const { context, requestMock } = createLoadStructuresContext({ currentSelection: undefined, fallbackSelection: [] });
+		const { context, requestMock } = createLoadStructuresContext({
+			currentSelection: undefined,
+			fallbackSelection: [],
+		});
 		const result = await loadStructures.call(context);
 		expect(result).toEqual([]);
 		expect(requestMock).not.toHaveBeenCalled();
@@ -69,9 +72,7 @@ describe('loadStructures helper', () => {
 			responses: [
 				{
 					spaceInfo: {
-						structures: [
-							{ id: 'solo-structure', name: 'Solo' },
-						],
+						structures: [{ id: 'solo-structure', name: 'Solo' }],
 					},
 				},
 			],
@@ -112,9 +113,7 @@ describe('loadStructures helper', () => {
 						},
 					},
 					data: {
-						structures: [
-							{ id: 'structure-d', name: 'Delta' },
-						],
+						structures: [{ id: 'structure-d', name: 'Delta' }],
 					},
 				},
 			],
@@ -131,11 +130,11 @@ describe('loadStructures helper', () => {
 			'capacitiesApi',
 			expect.objectContaining({ qs: { spaceid: 'space-beta' } }),
 		);
-			expect(result).toEqual([
-				{ name: 'Alpha (Space-Alpha)', value: 'structure-a' },
-				{ name: 'Beta (Space-Alpha)', value: 'structure-b' },
-				{ name: 'Delta (Space-Beta)', value: 'structure-d' },
-				{ name: 'Gamma (Space-Beta)', value: 'structure-c' },
+		expect(result).toEqual([
+			{ name: 'Alpha (Space-Alpha)', value: 'structure-a' },
+			{ name: 'Beta (Space-Alpha)', value: 'structure-b' },
+			{ name: 'Delta (Space-Beta)', value: 'structure-d' },
+			{ name: 'Gamma (Space-Beta)', value: 'structure-c' },
 		]);
 	});
 });

--- a/nodes/Capacities/__tests__/ResourceDescription.test.ts
+++ b/nodes/Capacities/__tests__/ResourceDescription.test.ts
@@ -6,11 +6,10 @@ describe('Resource description', () => {
 		const resourceProperty = getProperty(resources, 'resource');
 		expect(resourceProperty).toBeDefined();
 		expect(resourceProperty?.default).toBe('dailyNote');
-		expect(getOptions(resourceProperty).map((option) => option.value).sort()).toEqual([
-			'dailyNote',
-			'search',
-			'space',
-			'weblink',
-		]);
+		expect(
+			getOptions(resourceProperty)
+				.map((option) => option.value)
+				.sort(),
+		).toEqual(['dailyNote', 'search', 'space', 'weblink']);
 	});
 });

--- a/nodes/Capacities/__tests__/testUtils.ts
+++ b/nodes/Capacities/__tests__/testUtils.ts
@@ -17,8 +17,9 @@ export const getProperty = (
 	});
 
 export const getOptions = (property?: INodeProperties): INodePropertyOptions[] =>
-	(property?.options ?? []).filter((option): option is INodePropertyOptions =>
-		typeof (option as INodePropertyOptions).value === 'string',
+	(property?.options ?? []).filter(
+		(option): option is INodePropertyOptions =>
+			typeof (option as INodePropertyOptions).value === 'string',
 	);
 
 export const getCollectionOption = (


### PR DESCRIPTION
🎯 **What:** Marked the `capacitiesApi` credential as required in the node description.
⚠️ **Risk:** When credentials are optional, users might attempt to run the node without providing a Bearer token, leading to unauthenticated API requests and avoidable runtime errors.
🛡️ **Solution:** Set `required: true` for the `capacitiesApi` credential to force users to configure authentication.

---
*PR created automatically by Jules for task [12447191815734684528](https://jules.google.com/task/12447191815734684528) started by @cmuench*