### PR TITLE
feat(capacities): add v2 tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the code for the n8n nodes that interact with the [Capa
 
 This node ships two versions side by side:
 
-- **v2 (default for new nodes)** talks to the current [Capacities v1 API](https://developers.capacities.io/api/overview/migration). Tokens are scoped to a single space, so there's no more Space ID selector. Weblink tags use the v1 property model and must be provided as existing `RootTag` object IDs.
+- **v2 (default for new nodes)** talks to the current [Capacities v1 API](https://developers.capacities.io/api/overview/migration). Tokens are scoped to a single space, so there's no more Space ID selector. Weblink tags use the v1 property model and are selected from existing `RootTag` objects.
 - **v1 (legacy, kept for existing workflows)** talks to the deprecated Capacities Beta API. Workflows created before this update keep using it unchanged. Capacities is retiring the Beta API on **2026-09-01** — after that date, `v1`-typed nodes will stop working and existing workflows should be re-saved with a new Capacities node (or have their node version bumped) to pick up `v2`.
 
 If you're building a new workflow, use a fresh Capacities node and a personal API token generated under **Settings → Capacities API** in the desktop app.
@@ -32,7 +32,7 @@ pnpm add @muench-dev/n8n-nodes-capacities
 - Search operations
 	- Query notes, bookmarks, or other content, optionally filtered by structure type
 - Weblink operations
-	- Save URLs into Capacities, including optional markdown, title, description, and tag ID properties
+	- Save URLs into Capacities, including optional markdown, title, description, and tag properties
 - Tag operations
 	- Save tags as `RootTag` objects for later use in object tag properties
 - Daily note operations

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pnpm add @muench-dev/n8n-nodes-capacities
 - Search operations
 	- Query notes, bookmarks, or other content, optionally filtered by structure type
 - Weblink operations
-	- Save URLs into Capacities, including optional markdown, title, description, and tag properties
+	- Save URLs into Capacities, including optional markdown, title, description, and searchable tag properties
 - Tag operations
 	- Save tags as `RootTag` objects for later use in object tag properties
 - Daily note operations

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the code for the n8n nodes that interact with the [Capa
 
 This node ships two versions side by side:
 
-- **v2 (default for new nodes)** talks to the current [Capacities v1 API](https://developers.capacities.io/api/overview/migration). Tokens are scoped to a single space, so there's no more Space ID selector. Note: the new `/object/url` endpoint has no `tags` parameter, so Weblink tags aren't supported in this version.
+- **v2 (default for new nodes)** talks to the current [Capacities v1 API](https://developers.capacities.io/api/overview/migration). Tokens are scoped to a single space, so there's no more Space ID selector. Weblink tags use the v1 property model and must be provided as existing `RootTag` object IDs.
 - **v1 (legacy, kept for existing workflows)** talks to the deprecated Capacities Beta API. Workflows created before this update keep using it unchanged. Capacities is retiring the Beta API on **2026-09-01** — after that date, `v1`-typed nodes will stop working and existing workflows should be re-saved with a new Capacities node (or have their node version bumped) to pick up `v2`.
 
 If you're building a new workflow, use a fresh Capacities node and a personal API token generated under **Settings → Capacities API** in the desktop app.
@@ -32,7 +32,9 @@ pnpm add @muench-dev/n8n-nodes-capacities
 - Search operations
 	- Query notes, bookmarks, or other content, optionally filtered by structure type
 - Weblink operations
-	- Save URLs into Capacities, including optional markdown, title, and description overrides
+	- Save URLs into Capacities, including optional markdown, title, description, and tag ID properties
+- Tag operations
+	- Save tags as `RootTag` objects for later use in object tag properties
 - Daily note operations
 	- Append markdown to a daily note, optionally skipping the automatic timestamp or targeting a specific date
 

--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -6,13 +6,15 @@ import { search } from './SearchDescription';
 import { weblink } from './WeblinkDescription';
 import { dailyNote } from './DailyNoteDescription';
 import { tag } from './TagDescription';
-import { loadStructures, loadTags } from './GeneralFunctions';
+import { loadStructures, searchTags } from './GeneralFunctions';
 
 export class CapacitiesV2 implements INodeType {
 	methods = {
 		loadOptions: {
 			loadStructures,
-			loadTags,
+		},
+		listSearch: {
+			searchTags,
 		},
 	};
 

--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -6,15 +6,13 @@ import { search } from './SearchDescription';
 import { weblink } from './WeblinkDescription';
 import { dailyNote } from './DailyNoteDescription';
 import { tag } from './TagDescription';
-import { loadStructures, searchTags } from './GeneralFunctions';
+import { loadStructures, loadTags } from './GeneralFunctions';
 
 export class CapacitiesV2 implements INodeType {
 	methods = {
 		loadOptions: {
 			loadStructures,
-		},
-		listSearch: {
-			searchTags,
+			loadTags,
 		},
 	};
 

--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -5,6 +5,7 @@ import { space } from './SpaceDescription';
 import { search } from './SearchDescription';
 import { weblink } from './WeblinkDescription';
 import { dailyNote } from './DailyNoteDescription';
+import { tag } from './TagDescription';
 import { loadStructures } from './GeneralFunctions';
 
 export class CapacitiesV2 implements INodeType {
@@ -43,6 +44,6 @@ export class CapacitiesV2 implements INodeType {
 				'Content-Type': 'application/json',
 			},
 		},
-		properties: [...resources, ...space, ...search, ...weblink, ...dailyNote, ...general],
+		properties: [...resources, ...space, ...search, ...weblink, ...dailyNote, ...tag, ...general],
 	};
 }

--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -6,12 +6,13 @@ import { search } from './SearchDescription';
 import { weblink } from './WeblinkDescription';
 import { dailyNote } from './DailyNoteDescription';
 import { tag } from './TagDescription';
-import { loadStructures } from './GeneralFunctions';
+import { loadStructures, loadTags } from './GeneralFunctions';
 
 export class CapacitiesV2 implements INodeType {
 	methods = {
 		loadOptions: {
 			loadStructures,
+			loadTags,
 		},
 	};
 

--- a/nodes/Capacities/V2/GeneralFunctions.ts
+++ b/nodes/Capacities/V2/GeneralFunctions.ts
@@ -1,4 +1,4 @@
-import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+import type { ILoadOptionsFunctions, INodeListSearchResult, INodePropertyOptions } from 'n8n-workflow';
 
 export async function loadStructures(
 	this: ILoadOptionsFunctions,
@@ -17,13 +17,14 @@ export async function loadStructures(
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function loadTags(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-	const currentSearch = this.getCurrentNodeParameter('weblinkOptions.tagSearch');
-	const fallbackSearch = this.getNodeParameter('weblinkOptions.tagSearch', '') as string;
-	const query = String(currentSearch ?? fallbackSearch).trim();
+export async function searchTags(
+	this: ILoadOptionsFunctions,
+	filter?: string,
+): Promise<INodeListSearchResult> {
+	const query = String(filter ?? '').trim();
 
 	if (!query) {
-		return [];
+		return { results: [] };
 	}
 
 	const response = (await this.helpers.requestWithAuthentication.call(this, 'capacitiesApi', {
@@ -40,7 +41,9 @@ export async function loadTags(this: ILoadOptionsFunctions): Promise<INodeProper
 		results: Array<{ id: string; title: string }>;
 	};
 
-	return response.results
-		.map((tag) => ({ name: tag.title, value: tag.id }))
-		.sort((a, b) => a.name.localeCompare(b.name));
+	return {
+		results: response.results
+			.map((tag) => ({ name: tag.title, value: tag.id }))
+			.sort((a, b) => a.name.localeCompare(b.name)),
+	};
 }

--- a/nodes/Capacities/V2/GeneralFunctions.ts
+++ b/nodes/Capacities/V2/GeneralFunctions.ts
@@ -18,15 +18,23 @@ export async function loadStructures(
 }
 
 export async function loadTags(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const currentSearch = this.getCurrentNodeParameter('weblinkOptions.tagSearch');
+	const fallbackSearch = this.getNodeParameter('weblinkOptions.tagSearch', '') as string;
+	const query = String(currentSearch ?? fallbackSearch).trim();
+
+	if (!query) {
+		return [];
+	}
+
 	const response = (await this.helpers.requestWithAuthentication.call(this, 'capacitiesApi', {
 		method: 'POST',
 		baseURL: 'https://api.capacities.io',
 		url: '/objects/search',
 		json: true,
 		body: {
-			query: '',
+			query,
 			structureIds: ['RootTag'],
-			limit: 100,
+			limit: 50,
 		},
 	})) as {
 		results: Array<{ id: string; title: string }>;

--- a/nodes/Capacities/V2/GeneralFunctions.ts
+++ b/nodes/Capacities/V2/GeneralFunctions.ts
@@ -1,4 +1,4 @@
-import type { ILoadOptionsFunctions, INodeListSearchResult, INodePropertyOptions } from 'n8n-workflow';
+import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
 
 export async function loadStructures(
 	this: ILoadOptionsFunctions,
@@ -17,33 +17,33 @@ export async function loadStructures(
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function searchTags(
-	this: ILoadOptionsFunctions,
-	filter?: string,
-): Promise<INodeListSearchResult> {
-	const query = String(filter ?? '').trim();
+export async function loadTags(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const tagById = new Map<string, string>();
+	const queries = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
-	if (!query) {
-		return { results: [] };
-	}
+	await Promise.all(
+		queries.map(async (query) => {
+			const response = (await this.helpers.requestWithAuthentication.call(this, 'capacitiesApi', {
+				method: 'POST',
+				baseURL: 'https://api.capacities.io',
+				url: '/objects/search',
+				json: true,
+				body: {
+					query,
+					structureIds: ['RootTag'],
+					limit: 50,
+				},
+			})) as {
+				results: Array<{ id: string; title: string }>;
+			};
 
-	const response = (await this.helpers.requestWithAuthentication.call(this, 'capacitiesApi', {
-		method: 'POST',
-		baseURL: 'https://api.capacities.io',
-		url: '/objects/search',
-		json: true,
-		body: {
-			query,
-			structureIds: ['RootTag'],
-			limit: 50,
-		},
-	})) as {
-		results: Array<{ id: string; title: string }>;
-	};
+			for (const tag of response.results) {
+				tagById.set(tag.id, tag.title);
+			}
+		}),
+	);
 
-	return {
-		results: response.results
-			.map((tag) => ({ name: tag.title, value: tag.id }))
-			.sort((a, b) => a.name.localeCompare(b.name)),
-	};
+	return [...tagById.entries()]
+		.map(([id, title]) => ({ name: title, value: id }))
+		.sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/nodes/Capacities/V2/GeneralFunctions.ts
+++ b/nodes/Capacities/V2/GeneralFunctions.ts
@@ -16,3 +16,23 @@ export async function loadStructures(
 		.map((structure) => ({ name: structure.title, value: structure.id }))
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
+
+export async function loadTags(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
+	const response = (await this.helpers.requestWithAuthentication.call(this, 'capacitiesApi', {
+		method: 'POST',
+		baseURL: 'https://api.capacities.io',
+		url: '/objects/search',
+		json: true,
+		body: {
+			query: '',
+			structureIds: ['RootTag'],
+			limit: 100,
+		},
+	})) as {
+		results: Array<{ id: string; title: string }>;
+	};
+
+	return response.results
+		.map((tag) => ({ name: tag.title, value: tag.id }))
+		.sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/nodes/Capacities/V2/ResourceDescription.ts
+++ b/nodes/Capacities/V2/ResourceDescription.ts
@@ -1,1 +1,33 @@
-export { resources } from '../V1/ResourceDescription';
+import type { INodeProperties } from 'n8n-workflow';
+
+export const resources: INodeProperties[] = [
+	{
+		displayName: 'Resource',
+		name: 'resource',
+		type: 'options',
+		noDataExpression: true,
+		options: [
+			{
+				name: 'Daily Note',
+				value: 'dailyNote',
+			},
+			{
+				name: 'Space',
+				value: 'space',
+			},
+			{
+				name: 'Search',
+				value: 'search',
+			},
+			{
+				name: 'Tag',
+				value: 'tag',
+			},
+			{
+				name: 'Weblink',
+				value: 'weblink',
+			},
+		],
+		default: 'dailyNote',
+	},
+];

--- a/nodes/Capacities/V2/ResourceDescription.ts
+++ b/nodes/Capacities/V2/ResourceDescription.ts
@@ -12,12 +12,12 @@ export const resources: INodeProperties[] = [
 				value: 'dailyNote',
 			},
 			{
-				name: 'Space',
-				value: 'space',
-			},
-			{
 				name: 'Search',
 				value: 'search',
+			},
+			{
+				name: 'Space',
+				value: 'space',
 			},
 			{
 				name: 'Tag',

--- a/nodes/Capacities/V2/TagDescription.ts
+++ b/nodes/Capacities/V2/TagDescription.ts
@@ -1,0 +1,57 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const tag: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		required: true,
+		default: 'save',
+		options: [
+			{
+				name: 'Save',
+				value: 'save',
+				description: 'Create a tag object',
+				action: 'Save a tag',
+				routing: {
+					request: {
+						url: '/object',
+						method: 'POST',
+						json: true,
+						body: {
+							structureId: 'RootTag',
+							properties: {
+								title: {
+									type: 'title',
+									title: {
+										value: '={{$parameter.title}}',
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['tag'],
+			},
+		},
+	},
+	{
+		displayName: 'Title',
+		name: 'title',
+		type: 'string',
+		description: 'The title of the tag to create',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['tag'],
+				operation: ['save'],
+			},
+		},
+	},
+];

--- a/nodes/Capacities/V2/WeblinkDescription.ts
+++ b/nodes/Capacities/V2/WeblinkDescription.ts
@@ -81,15 +81,15 @@ export const weblink: INodeProperties[] = [
 				default: '',
 			},
 			{
-				displayName: 'Tag IDs',
+				displayName: 'Tag Names or IDs',
 				name: 'tagIds',
-				type: 'string',
+				type: 'multiOptions',
 				typeOptions: {
-					multipleValues: true,
-					multipleValueButtonText: 'Add Tag ID',
+					loadOptionsMethod: 'loadTags',
 				},
-				default: '',
-				description: 'Existing RootTag object IDs to assign to the weblink',
+				default: [],
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 			},
 		],
 		displayOptions: {

--- a/nodes/Capacities/V2/WeblinkDescription.ts
+++ b/nodes/Capacities/V2/WeblinkDescription.ts
@@ -22,7 +22,7 @@ export const weblink: INodeProperties[] = [
 							url: '={{$parameter.url}}',
 							markdown: '={{$parameter.weblinkOptions.markdown || undefined}}',
 							properties:
-								'={{(() => { const o = $parameter.weblinkOptions; const p = {}; if (o.titleOverwrite) { p.title = { type: "title", title: { value: o.titleOverwrite } }; } if (o.descriptionOverwrite) { p.description = { type: "text", text: { value: o.descriptionOverwrite } }; } const tagIds = Array.isArray(o.tagIds) ? o.tagIds.filter(Boolean) : (o.tagIds ? [o.tagIds] : []); if (tagIds.length) { p.tags = { type: "entity", entity: tagIds.map((id) => ({ id })) }; } return Object.keys(p).length ? p : undefined; })()}}',
+								'={{(() => { const o = $parameter.weblinkOptions; const p = {}; if (o.titleOverwrite) { p.title = { type: "title", title: { value: o.titleOverwrite } }; } if (o.descriptionOverwrite) { p.description = { type: "text", text: { value: o.descriptionOverwrite } }; } const tags = Array.isArray(o.tags?.values) ? o.tags.values : []; const tagIds = tags.map((tag) => typeof tag.tagId === "object" ? tag.tagId.value : tag.tagId).filter(Boolean); if (tagIds.length) { p.tags = { type: "entity", entity: tagIds.map((id) => ({ id })) }; } return Object.keys(p).length ? p : undefined; })()}}',
 						},
 					},
 				},
@@ -73,22 +73,46 @@ export const weblink: INodeProperties[] = [
 				hint: 'Text formatted as markdown that will be added to the notes section',
 			},
 			{
-				displayName: 'Tag Names or IDs',
-				name: 'tagIds',
-				type: 'multiOptions',
+				displayName: 'Tags',
+				name: 'tags',
+				type: 'fixedCollection',
 				typeOptions: {
-					loadOptionsMethod: 'loadTags',
+					multipleValues: true,
 				},
-				default: [],
-				description:
-					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
-			},
-			{
-				displayName: 'Tag Search',
-				name: 'tagSearch',
-				type: 'string',
-				default: '',
-				description: 'Search term used to load existing tags for selection',
+				default: {},
+				placeholder: 'Add Tag',
+				options: [
+					{
+						displayName: 'Tag',
+						name: 'values',
+						values: [
+							{
+								displayName: 'Tag Name or ID',
+								name: 'tagId',
+								type: 'resourceLocator',
+								default: { mode: 'list', value: '' },
+								description:
+									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+								modes: [
+									{
+										displayName: 'From List',
+										name: 'list',
+										type: 'list',
+										typeOptions: {
+											searchListMethod: 'searchTags',
+											searchFilterRequired: true,
+										},
+									},
+									{
+										displayName: 'By ID',
+										name: 'id',
+										type: 'string',
+									},
+								],
+							},
+						],
+					},
+				],
 			},
 			{
 				displayName: 'Title Overwrite',

--- a/nodes/Capacities/V2/WeblinkDescription.ts
+++ b/nodes/Capacities/V2/WeblinkDescription.ts
@@ -22,7 +22,7 @@ export const weblink: INodeProperties[] = [
 							url: '={{$parameter.url}}',
 							markdown: '={{$parameter.weblinkOptions.markdown || undefined}}',
 							properties:
-								'={{(() => { const o = $parameter.weblinkOptions; const p = {}; if (o.titleOverwrite) { p.title = { type: "title", title: { value: o.titleOverwrite } }; } if (o.descriptionOverwrite) { p.description = { type: "text", text: { value: o.descriptionOverwrite } }; } return Object.keys(p).length ? p : undefined; })()}}',
+								'={{(() => { const o = $parameter.weblinkOptions; const p = {}; if (o.titleOverwrite) { p.title = { type: "title", title: { value: o.titleOverwrite } }; } if (o.descriptionOverwrite) { p.description = { type: "text", text: { value: o.descriptionOverwrite } }; } const tagIds = Array.isArray(o.tagIds) ? o.tagIds.filter(Boolean) : (o.tagIds ? [o.tagIds] : []); if (tagIds.length) { p.tags = { type: "entity", entity: tagIds.map((id) => ({ id })) }; } return Object.keys(p).length ? p : undefined; })()}}',
 						},
 					},
 				},
@@ -79,6 +79,17 @@ export const weblink: INodeProperties[] = [
 				description: 'The description of the weblink',
 				hint: 'If empty, the description will be fetched from the URL',
 				default: '',
+			},
+			{
+				displayName: 'Tag IDs',
+				name: 'tagIds',
+				type: 'string',
+				typeOptions: {
+					multipleValues: true,
+					multipleValueButtonText: 'Add Tag ID',
+				},
+				default: '',
+				description: 'Existing RootTag object IDs to assign to the weblink',
 			},
 		],
 		displayOptions: {

--- a/nodes/Capacities/V2/WeblinkDescription.ts
+++ b/nodes/Capacities/V2/WeblinkDescription.ts
@@ -57,28 +57,20 @@ export const weblink: INodeProperties[] = [
 		noDataExpression: false,
 		options: [
 			{
-				displayName: 'Markdown',
-				name: 'markdown',
-				type: 'string',
-				default: '',
-				description: 'The markdown text of the weblink',
-				hint: 'Text formatted as markdown that will be added to the notes section',
-			},
-			{
-				displayName: 'Title Overwrite',
-				name: 'titleOverwrite',
-				type: 'string',
-				description: 'The title of the weblink',
-				hint: 'If empty, the title will be fetched from the URL',
-				default: '',
-			},
-			{
 				displayName: 'Description Overwrite',
 				name: 'descriptionOverwrite',
 				type: 'string',
 				description: 'The description of the weblink',
 				hint: 'If empty, the description will be fetched from the URL',
 				default: '',
+			},
+			{
+				displayName: 'Markdown',
+				name: 'markdown',
+				type: 'string',
+				default: '',
+				description: 'The markdown text of the weblink',
+				hint: 'Text formatted as markdown that will be added to the notes section',
 			},
 			{
 				displayName: 'Tag Names or IDs',
@@ -90,6 +82,21 @@ export const weblink: INodeProperties[] = [
 				default: [],
 				description:
 					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
+			},
+			{
+				displayName: 'Tag Search',
+				name: 'tagSearch',
+				type: 'string',
+				default: '',
+				description: 'Search term used to load existing tags for selection',
+			},
+			{
+				displayName: 'Title Overwrite',
+				name: 'titleOverwrite',
+				type: 'string',
+				description: 'The title of the weblink',
+				hint: 'If empty, the title will be fetched from the URL',
+				default: '',
 			},
 		],
 		displayOptions: {

--- a/nodes/Capacities/V2/WeblinkDescription.ts
+++ b/nodes/Capacities/V2/WeblinkDescription.ts
@@ -22,7 +22,7 @@ export const weblink: INodeProperties[] = [
 							url: '={{$parameter.url}}',
 							markdown: '={{$parameter.weblinkOptions.markdown || undefined}}',
 							properties:
-								'={{(() => { const o = $parameter.weblinkOptions; const p = {}; if (o.titleOverwrite) { p.title = { type: "title", title: { value: o.titleOverwrite } }; } if (o.descriptionOverwrite) { p.description = { type: "text", text: { value: o.descriptionOverwrite } }; } const tags = Array.isArray(o.tags?.values) ? o.tags.values : []; const tagIds = tags.map((tag) => typeof tag.tagId === "object" ? tag.tagId.value : tag.tagId).filter(Boolean); if (tagIds.length) { p.tags = { type: "entity", entity: tagIds.map((id) => ({ id })) }; } return Object.keys(p).length ? p : undefined; })()}}',
+								'={{(() => { const o = $parameter.weblinkOptions; const p = {}; if (o.titleOverwrite) { p.title = { type: "title", title: { value: o.titleOverwrite } }; } if (o.descriptionOverwrite) { p.description = { type: "text", text: { value: o.descriptionOverwrite } }; } const tagIds = Array.isArray(o.tagIds) ? o.tagIds.filter(Boolean) : (o.tagIds ? [o.tagIds] : []); if (tagIds.length) { p.tags = { type: "entity", entity: tagIds.map((id) => ({ id })) }; } return Object.keys(p).length ? p : undefined; })()}}',
 						},
 					},
 				},
@@ -73,46 +73,15 @@ export const weblink: INodeProperties[] = [
 				hint: 'Text formatted as markdown that will be added to the notes section',
 			},
 			{
-				displayName: 'Tags',
-				name: 'tags',
-				type: 'fixedCollection',
+				displayName: 'Tag Names or IDs',
+				name: 'tagIds',
+				type: 'multiOptions',
 				typeOptions: {
-					multipleValues: true,
+					loadOptionsMethod: 'loadTags',
 				},
-				default: {},
-				placeholder: 'Add Tag',
-				options: [
-					{
-						displayName: 'Tag',
-						name: 'values',
-						values: [
-							{
-								displayName: 'Tag Name or ID',
-								name: 'tagId',
-								type: 'resourceLocator',
-								default: { mode: 'list', value: '' },
-								description:
-									'Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
-								modes: [
-									{
-										displayName: 'From List',
-										name: 'list',
-										type: 'list',
-										typeOptions: {
-											searchListMethod: 'searchTags',
-											searchFilterRequired: true,
-										},
-									},
-									{
-										displayName: 'By ID',
-										name: 'id',
-										type: 'string',
-									},
-								],
-							},
-						],
-					},
-				],
+				default: [],
+				description:
+					'Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>',
 			},
 			{
 				displayName: 'Title Overwrite',

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -30,6 +30,6 @@ describe('CapacitiesV2 node', () => {
 	it('registers load option helpers', () => {
 		const node = new CapacitiesV2();
 		expect(node.methods.loadOptions.loadStructures).toBeDefined();
-		expect(node.methods.loadOptions.loadTags).toBeDefined();
+		expect(node.methods.listSearch.searchTags).toBeDefined();
 	});
 });

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -30,6 +30,6 @@ describe('CapacitiesV2 node', () => {
 	it('registers load option helpers', () => {
 		const node = new CapacitiesV2();
 		expect(node.methods.loadOptions.loadStructures).toBeDefined();
-		expect(node.methods.listSearch.searchTags).toBeDefined();
+		expect(node.methods.loadOptions.loadTags).toBeDefined();
 	});
 });

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -22,6 +22,7 @@ describe('CapacitiesV2 node', () => {
 			'dailyNote',
 			'search',
 			'space',
+			'tag',
 			'weblink',
 		]);
 	});

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -27,8 +27,9 @@ describe('CapacitiesV2 node', () => {
 		]);
 	});
 
-	it('registers loadStructures helper for load options', () => {
+	it('registers load option helpers', () => {
 		const node = new CapacitiesV2();
 		expect(node.methods.loadOptions.loadStructures).toBeDefined();
+		expect(node.methods.loadOptions.loadTags).toBeDefined();
 	});
 });

--- a/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
+++ b/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
@@ -2,12 +2,24 @@ import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
 import { loadStructures, loadTags } from '../GeneralFunctions';
 
-const createContext = (response: Record<string, unknown>) => {
+const createContext = (response: Record<string, unknown>, tagSearch = '') => {
 	const requestMock = jest.fn().mockResolvedValue(response);
 	const context = {
 		helpers: {
 			requestWithAuthentication: requestMock,
 		},
+		getCurrentNodeParameter: jest.fn((parameterName: string) => {
+			if (parameterName === 'weblinkOptions.tagSearch') {
+				return tagSearch;
+			}
+			return undefined;
+		}),
+		getNodeParameter: jest.fn((parameterName: string, defaultValue: unknown) => {
+			if (parameterName === 'weblinkOptions.tagSearch') {
+				return tagSearch || defaultValue;
+			}
+			return defaultValue;
+		}),
 	} as unknown as ILoadOptionsFunctions;
 
 	return { context, requestMock };
@@ -41,13 +53,25 @@ describe('loadStructures helper (v1)', () => {
 });
 
 describe('loadTags helper (v2)', () => {
+	it('returns no options without hitting the API when no tag search is set', async () => {
+		const { context, requestMock } = createContext({ results: [] });
+
+		const result = await loadTags.call(context);
+
+		expect(result).toEqual([]);
+		expect(requestMock).not.toHaveBeenCalled();
+	});
+
 	it('requests RootTag search results and maps id/title pairs', async () => {
-		const { context, requestMock } = createContext({
-			results: [
-				{ id: 'tag-b', title: 'Beta' },
-				{ id: 'tag-a', title: 'Alpha' },
-			],
-		});
+		const { context, requestMock } = createContext(
+			{
+				results: [
+					{ id: 'tag-b', title: 'Beta' },
+					{ id: 'tag-a', title: 'Alpha' },
+				],
+			},
+			'a',
+		);
 
 		const result = await loadTags.call(context);
 
@@ -58,9 +82,9 @@ describe('loadTags helper (v2)', () => {
 				url: '/objects/search',
 				method: 'POST',
 				body: {
-					query: '',
+					query: 'a',
 					structureIds: ['RootTag'],
-					limit: 100,
+					limit: 50,
 				},
 			}),
 		);

--- a/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
+++ b/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
@@ -1,6 +1,6 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
-import { loadStructures } from '../GeneralFunctions';
+import { loadStructures, loadTags } from '../GeneralFunctions';
 
 const createContext = (response: Record<string, unknown>) => {
 	const requestMock = jest.fn().mockResolvedValue(response);
@@ -36,6 +36,37 @@ describe('loadStructures helper (v1)', () => {
 		expect(result).toEqual([
 			{ name: 'Alpha', value: 'structure-a' },
 			{ name: 'Beta', value: 'structure-b' },
+		]);
+	});
+});
+
+describe('loadTags helper (v2)', () => {
+	it('requests RootTag search results and maps id/title pairs', async () => {
+		const { context, requestMock } = createContext({
+			results: [
+				{ id: 'tag-b', title: 'Beta' },
+				{ id: 'tag-a', title: 'Alpha' },
+			],
+		});
+
+		const result = await loadTags.call(context);
+
+		expect(requestMock).toHaveBeenCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledWith(
+			'capacitiesApi',
+			expect.objectContaining({
+				url: '/objects/search',
+				method: 'POST',
+				body: {
+					query: '',
+					structureIds: ['RootTag'],
+					limit: 100,
+				},
+			}),
+		);
+		expect(result).toEqual([
+			{ name: 'Alpha', value: 'tag-a' },
+			{ name: 'Beta', value: 'tag-b' },
 		]);
 	});
 });

--- a/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
+++ b/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
@@ -1,6 +1,6 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
-import { loadStructures, searchTags } from '../GeneralFunctions';
+import { loadStructures, loadTags } from '../GeneralFunctions';
 
 const createContext = (response: Record<string, unknown>) => {
 	const requestMock = jest.fn().mockResolvedValue(response);
@@ -40,27 +40,19 @@ describe('loadStructures helper (v1)', () => {
 	});
 });
 
-describe('searchTags helper (v2)', () => {
-	it('returns no options without hitting the API when no filter is set', async () => {
-		const { context, requestMock } = createContext({ results: [] });
-
-		const result = await searchTags.call(context);
-
-		expect(result).toEqual({ results: [] });
-		expect(requestMock).not.toHaveBeenCalled();
-	});
-
-	it('requests RootTag search results and maps id/title pairs', async () => {
+describe('loadTags helper (v2)', () => {
+	it('loads tag options from valid RootTag searches and deduplicates results', async () => {
 		const { context, requestMock } = createContext({
 			results: [
 				{ id: 'tag-b', title: 'Beta' },
 				{ id: 'tag-a', title: 'Alpha' },
+				{ id: 'tag-a', title: 'Alpha' },
 			],
 		});
 
-		const result = await searchTags.call(context, 'a');
+		const result = await loadTags.call(context);
 
-		expect(requestMock).toHaveBeenCalledTimes(1);
+		expect(requestMock).toHaveBeenCalledTimes(26);
 		expect(requestMock).toHaveBeenCalledWith(
 			'capacitiesApi',
 			expect.objectContaining({
@@ -73,11 +65,9 @@ describe('searchTags helper (v2)', () => {
 				},
 			}),
 		);
-		expect(result).toEqual({
-			results: [
-				{ name: 'Alpha', value: 'tag-a' },
-				{ name: 'Beta', value: 'tag-b' },
-			],
-		});
+		expect(result).toEqual([
+			{ name: 'Alpha', value: 'tag-a' },
+			{ name: 'Beta', value: 'tag-b' },
+		]);
 	});
 });

--- a/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
+++ b/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
@@ -1,25 +1,13 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
 
-import { loadStructures, loadTags } from '../GeneralFunctions';
+import { loadStructures, searchTags } from '../GeneralFunctions';
 
-const createContext = (response: Record<string, unknown>, tagSearch = '') => {
+const createContext = (response: Record<string, unknown>) => {
 	const requestMock = jest.fn().mockResolvedValue(response);
 	const context = {
 		helpers: {
 			requestWithAuthentication: requestMock,
 		},
-		getCurrentNodeParameter: jest.fn((parameterName: string) => {
-			if (parameterName === 'weblinkOptions.tagSearch') {
-				return tagSearch;
-			}
-			return undefined;
-		}),
-		getNodeParameter: jest.fn((parameterName: string, defaultValue: unknown) => {
-			if (parameterName === 'weblinkOptions.tagSearch') {
-				return tagSearch || defaultValue;
-			}
-			return defaultValue;
-		}),
 	} as unknown as ILoadOptionsFunctions;
 
 	return { context, requestMock };
@@ -52,28 +40,25 @@ describe('loadStructures helper (v1)', () => {
 	});
 });
 
-describe('loadTags helper (v2)', () => {
-	it('returns no options without hitting the API when no tag search is set', async () => {
+describe('searchTags helper (v2)', () => {
+	it('returns no options without hitting the API when no filter is set', async () => {
 		const { context, requestMock } = createContext({ results: [] });
 
-		const result = await loadTags.call(context);
+		const result = await searchTags.call(context);
 
-		expect(result).toEqual([]);
+		expect(result).toEqual({ results: [] });
 		expect(requestMock).not.toHaveBeenCalled();
 	});
 
 	it('requests RootTag search results and maps id/title pairs', async () => {
-		const { context, requestMock } = createContext(
-			{
-				results: [
-					{ id: 'tag-b', title: 'Beta' },
-					{ id: 'tag-a', title: 'Alpha' },
-				],
-			},
-			'a',
-		);
+		const { context, requestMock } = createContext({
+			results: [
+				{ id: 'tag-b', title: 'Beta' },
+				{ id: 'tag-a', title: 'Alpha' },
+			],
+		});
 
-		const result = await loadTags.call(context);
+		const result = await searchTags.call(context, 'a');
 
 		expect(requestMock).toHaveBeenCalledTimes(1);
 		expect(requestMock).toHaveBeenCalledWith(
@@ -88,9 +73,11 @@ describe('loadTags helper (v2)', () => {
 				},
 			}),
 		);
-		expect(result).toEqual([
-			{ name: 'Alpha', value: 'tag-a' },
-			{ name: 'Beta', value: 'tag-b' },
-		]);
+		expect(result).toEqual({
+			results: [
+				{ name: 'Alpha', value: 'tag-a' },
+				{ name: 'Beta', value: 'tag-b' },
+			],
+		});
 	});
 });

--- a/nodes/Capacities/V2/__tests__/ResourceDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/ResourceDescription.test.ts
@@ -10,6 +10,7 @@ describe('Resource description (v1)', () => {
 			'dailyNote',
 			'search',
 			'space',
+			'tag',
 			'weblink',
 		]);
 	});

--- a/nodes/Capacities/V2/__tests__/TagDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/TagDescription.test.ts
@@ -1,0 +1,37 @@
+import { tag } from '../TagDescription';
+import { getOptions, getProperty } from './testUtils';
+
+describe('Tag description (v2)', () => {
+	it('creates tags with POST /object routing', () => {
+		const operationProperty = getProperty(tag, 'operation', 'tag');
+		expect(operationProperty).toBeDefined();
+		const saveOption = getOptions(operationProperty).find((option) => option.value === 'save');
+
+		expect(saveOption?.routing?.request).toMatchObject({
+			url: '/object',
+			method: 'POST',
+			json: true,
+			body: {
+				structureId: 'RootTag',
+				properties: {
+					title: {
+						type: 'title',
+						title: {
+							value: '={{$parameter.title}}',
+						},
+					},
+				},
+			},
+		});
+	});
+
+	it('exposes a required title field', () => {
+		const titleProperty = getProperty(tag, 'title', 'tag');
+
+		expect(titleProperty).toMatchObject({
+			type: 'string',
+			required: true,
+			default: '',
+		});
+	});
+});

--- a/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
@@ -28,24 +28,32 @@ describe('Weblink description (v2)', () => {
 		);
 		expect(names).toEqual(
 			expect.arrayContaining([
-				'markdown',
-				'titleOverwrite',
 				'descriptionOverwrite',
-				'tagSearch',
-				'tagIds',
+				'markdown',
+				'tags',
+				'titleOverwrite',
 			]),
 		);
 
 		const tagOption = (optionsProperty?.options ?? []).find(
-			(option) => (option as { name: string }).name === 'tagIds',
-		) as { type?: string; typeOptions?: { loadOptionsMethod?: string } } | undefined;
+			(option) => (option as { name: string }).name === 'tags',
+		) as { options?: Array<{ values?: unknown[] }>; type?: string; typeOptions?: unknown } | undefined;
 
 		expect(tagOption).toMatchObject({
-			type: 'multiOptions',
+			type: 'fixedCollection',
 			typeOptions: {
-				loadOptionsMethod: 'loadTags',
+				multipleValues: true,
 			},
 		});
+
+		expect(tagOption?.options?.[0].values).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					name: 'tagId',
+					type: 'resourceLocator',
+				}),
+			]),
+		);
 	});
 
 	it('maps Tag IDs to the v1 entity property shape', () => {
@@ -54,7 +62,8 @@ describe('Weblink description (v2)', () => {
 		const body = saveOption?.routing?.request?.body as { properties?: string } | undefined;
 		const propertiesExpression = body?.properties;
 
-		expect(propertiesExpression).toContain('o.tagIds');
+		expect(propertiesExpression).toContain('o.tags?.values');
+		expect(propertiesExpression).toContain('tag.tagId.value');
 		expect(propertiesExpression).toContain('p.tags = { type: "entity"');
 		expect(propertiesExpression).toContain('entity: tagIds.map((id) => ({ id }))');
 	});

--- a/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
@@ -27,7 +27,13 @@ describe('Weblink description (v2)', () => {
 			(option) => (option as { name: string }).name,
 		);
 		expect(names).toEqual(
-			expect.arrayContaining(['markdown', 'titleOverwrite', 'descriptionOverwrite', 'tagIds']),
+			expect.arrayContaining([
+				'markdown',
+				'titleOverwrite',
+				'descriptionOverwrite',
+				'tagSearch',
+				'tagIds',
+			]),
 		);
 
 		const tagOption = (optionsProperty?.options ?? []).find(

--- a/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
@@ -20,7 +20,7 @@ describe('Weblink description (v2)', () => {
 		expect(getProperty(weblink, 'spaceId', 'weblink')).toBeUndefined();
 	});
 
-	it('exposes Markdown, Title Overwrite, Description Overwrite, and Tag IDs', () => {
+	it('exposes Markdown, Title Overwrite, Description Overwrite, and selectable Tags', () => {
 		const optionsProperty = getProperty(weblink, 'weblinkOptions', 'weblink');
 		expect(optionsProperty?.type).toBe('collection');
 		const names = (optionsProperty?.options ?? []).map(
@@ -29,6 +29,17 @@ describe('Weblink description (v2)', () => {
 		expect(names).toEqual(
 			expect.arrayContaining(['markdown', 'titleOverwrite', 'descriptionOverwrite', 'tagIds']),
 		);
+
+		const tagOption = (optionsProperty?.options ?? []).find(
+			(option) => (option as { name: string }).name === 'tagIds',
+		) as { type?: string; typeOptions?: { loadOptionsMethod?: string } } | undefined;
+
+		expect(tagOption).toMatchObject({
+			type: 'multiOptions',
+			typeOptions: {
+				loadOptionsMethod: 'loadTags',
+			},
+		});
 	});
 
 	it('maps Tag IDs to the v1 entity property shape', () => {

--- a/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
@@ -1,7 +1,7 @@
 import { weblink } from '../WeblinkDescription';
 import { getOptions, getProperty } from './testUtils';
 
-describe('Weblink description (v1)', () => {
+describe('Weblink description (v2)', () => {
 	it('saves weblinks with POST /object/url routing', () => {
 		const operationProperty = getProperty(weblink, 'operation', 'weblink');
 		expect(operationProperty).toBeDefined();
@@ -20,15 +20,25 @@ describe('Weblink description (v1)', () => {
 		expect(getProperty(weblink, 'spaceId', 'weblink')).toBeUndefined();
 	});
 
-	it('exposes Markdown, Title Overwrite, and Description Overwrite, but no Tags', () => {
+	it('exposes Markdown, Title Overwrite, Description Overwrite, and Tag IDs', () => {
 		const optionsProperty = getProperty(weblink, 'weblinkOptions', 'weblink');
 		expect(optionsProperty?.type).toBe('collection');
 		const names = (optionsProperty?.options ?? []).map(
 			(option) => (option as { name: string }).name,
 		);
 		expect(names).toEqual(
-			expect.arrayContaining(['markdown', 'titleOverwrite', 'descriptionOverwrite']),
+			expect.arrayContaining(['markdown', 'titleOverwrite', 'descriptionOverwrite', 'tagIds']),
 		);
-		expect(names).not.toContain('tags');
+	});
+
+	it('maps Tag IDs to the v1 entity property shape', () => {
+		const operationProperty = getProperty(weblink, 'operation', 'weblink');
+		const saveOption = getOptions(operationProperty).find((option) => option.value === 'save');
+		const body = saveOption?.routing?.request?.body as { properties?: string } | undefined;
+		const propertiesExpression = body?.properties;
+
+		expect(propertiesExpression).toContain('o.tagIds');
+		expect(propertiesExpression).toContain('p.tags = { type: "entity"');
+		expect(propertiesExpression).toContain('entity: tagIds.map((id) => ({ id }))');
 	});
 });

--- a/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
@@ -30,30 +30,21 @@ describe('Weblink description (v2)', () => {
 			expect.arrayContaining([
 				'descriptionOverwrite',
 				'markdown',
-				'tags',
+				'tagIds',
 				'titleOverwrite',
 			]),
 		);
 
 		const tagOption = (optionsProperty?.options ?? []).find(
-			(option) => (option as { name: string }).name === 'tags',
-		) as { options?: Array<{ values?: unknown[] }>; type?: string; typeOptions?: unknown } | undefined;
+			(option) => (option as { name: string }).name === 'tagIds',
+		) as { type?: string; typeOptions?: { loadOptionsMethod?: string } } | undefined;
 
 		expect(tagOption).toMatchObject({
-			type: 'fixedCollection',
+			type: 'multiOptions',
 			typeOptions: {
-				multipleValues: true,
+				loadOptionsMethod: 'loadTags',
 			},
 		});
-
-		expect(tagOption?.options?.[0].values).toEqual(
-			expect.arrayContaining([
-				expect.objectContaining({
-					name: 'tagId',
-					type: 'resourceLocator',
-				}),
-			]),
-		);
 	});
 
 	it('maps Tag IDs to the v1 entity property shape', () => {
@@ -62,8 +53,7 @@ describe('Weblink description (v2)', () => {
 		const body = saveOption?.routing?.request?.body as { properties?: string } | undefined;
 		const propertiesExpression = body?.properties;
 
-		expect(propertiesExpression).toContain('o.tags?.values');
-		expect(propertiesExpression).toContain('tag.tagId.value');
+		expect(propertiesExpression).toContain('o.tagIds');
 		expect(propertiesExpression).toContain('p.tags = { type: "entity"');
 		expect(propertiesExpression).toContain('entity: tagIds.map((id) => ({ id }))');
 	});


### PR DESCRIPTION
## Summary
- add a V2 Tag resource to create RootTag objects
- allow V2 Weblink saves to assign existing RootTag object IDs
- document V2 tag behavior and cover the new descriptions with tests

## Testing
- rtk pnpm test
- rtk pnpm build