### PR TITLE
Migrate v2 nodes to official SDK and add object update/delete operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ pnpm add @muench-dev/n8n-nodes-capacities
 	- Save URLs into Capacities, including optional markdown, title, description, and searchable tag properties
 - Tag operations
 	- Save tags as `RootTag` objects for later use in object tag properties
+- Object operations
+	- Create an object of any structure/type, with a title plus optional additional properties, collections, and block content
 - Daily note operations
 	- Append markdown to a daily note, optionally skipping the automatic timestamp or targeting a specific date
 

--- a/nodes/Capacities/V1/__tests__/CapacitiesV1.node.test.ts
+++ b/nodes/Capacities/V1/__tests__/CapacitiesV1.node.test.ts
@@ -17,12 +17,11 @@ describe('CapacitiesV1 node', () => {
 		const node = new CapacitiesV1();
 		const resourceProperty = getProperty(node.description.properties, 'resource');
 		expect(resourceProperty?.type).toBe('options');
-		expect(getOptions(resourceProperty).map((option) => option.value).sort()).toEqual([
-			'dailyNote',
-			'search',
-			'space',
-			'weblink',
-		]);
+		expect(
+			getOptions(resourceProperty)
+				.map((option) => option.value)
+				.sort(),
+		).toEqual(['dailyNote', 'search', 'space', 'weblink']);
 	});
 
 	it('registers loadStructures helper for load options', () => {

--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -1,11 +1,13 @@
 import type {
 	IDataObject,
 	IExecuteFunctions,
+	INode,
 	INodeExecutionData,
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
+import { CapacitiesClient } from '@capacities/api';
 import { resources } from './ResourceDescription';
 import { general } from './GeneralDescription';
 import { space } from './SpaceDescription';
@@ -13,6 +15,7 @@ import { search } from './SearchDescription';
 import { weblink } from './WeblinkDescription';
 import { dailyNote } from './DailyNoteDescription';
 import { tag } from './TagDescription';
+import { object } from './ObjectDescription';
 import { loadStructures, loadTags } from './GeneralFunctions';
 
 type WeblinkOptions = {
@@ -22,12 +25,17 @@ type WeblinkOptions = {
 	tagIds?: string | string[];
 };
 
-type RequestOptions = {
-	method: 'GET' | 'POST';
-	baseURL: string;
-	url: string;
-	json: true;
-	body?: IDataObject;
+type ObjectAdditionalFields = {
+	propertiesJson?: string;
+	collectionIds?: string;
+	blocksJson?: string;
+	propertiesToSend?: {
+		property?: Array<{
+			id: string;
+			type: string;
+			value: unknown;
+		}>;
+	};
 };
 
 const WEBLINK_TAGS_UNSUPPORTED_MESSAGE =
@@ -79,6 +87,153 @@ function getWeblinkBody(url: string, options: WeblinkOptions): IDataObject {
 	return body;
 }
 
+function parseJsonField(
+	value: string | undefined,
+	fieldLabel: string,
+	node: INode,
+	itemIndex: number,
+): IDataObject | undefined {
+	if (!value || !value.trim() || value.trim() === '{}') {
+		return undefined;
+	}
+
+	try {
+		return JSON.parse(value) as IDataObject;
+	} catch (error) {
+		throw new NodeOperationError(
+			node,
+			`Invalid JSON in ${fieldLabel}: ${(error as Error).message}`,
+			{
+				itemIndex,
+			},
+		);
+	}
+}
+
+function parseEntityArray(val: unknown): Array<{ id: string }> {
+	if (!val) {
+		return [];
+	}
+
+	if (Array.isArray(val)) {
+		return val
+			.map((item) => {
+				if (typeof item === 'string') {
+					return { id: item.trim() };
+				}
+				if (item && typeof item === 'object') {
+					const id = (item as { id?: unknown })?.id;
+					if (typeof id === 'string') {
+						return { id: id.trim() };
+					}
+				}
+				return null;
+			})
+			.filter((x): x is { id: string } => x !== null && !!x.id);
+	}
+
+	if (typeof val === 'string') {
+		const trimmed = val.trim();
+		if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+			try {
+				const parsed = JSON.parse(trimmed);
+				if (Array.isArray(parsed)) {
+					return parseEntityArray(parsed);
+				}
+			} catch (_) {}
+		}
+
+		return trimmed
+			.split(',')
+			.map((id) => id.trim())
+			.filter(Boolean)
+			.map((id) => ({ id }));
+	}
+
+	return [];
+}
+
+function mapUiPropertyToApi(prop: { id: string; type: string; value: unknown }): IDataObject {
+	const type = prop.type;
+	const val = prop.value;
+
+	if (type === 'text') {
+		return { type: 'text', text: { value: String(val ?? '') } };
+	} else if (type === 'title') {
+		return { type: 'title', title: { value: String(val ?? '') } };
+	} else if (type === 'number') {
+		const num = Number(val);
+		return { type: 'number', number: { value: isNaN(num) ? null : num } };
+	} else if (type === 'boolean') {
+		if (typeof val === 'boolean') {
+			return { type: 'boolean', boolean: { value: val } };
+		}
+		return { type: 'boolean', boolean: { value: String(val).toLowerCase() === 'true' } };
+	} else if (type === 'url') {
+		return { type: 'url', url: { value: String(val ?? '') } };
+	} else if (type === 'date') {
+		return { type: 'date', date: { start: String(val ?? '') } };
+	} else if (type === 'label') {
+		return {
+			type: 'label',
+			label: parseEntityArray(val),
+		};
+	} else if (type === 'entity') {
+		return {
+			type: 'entity',
+			entity: parseEntityArray(val),
+		};
+	}
+	return {};
+}
+
+function getCreateObjectBody(
+	structureId: string,
+	title: string,
+	additionalFields: ObjectAdditionalFields,
+	node: INode,
+	itemIndex: number,
+): IDataObject {
+	const properties: IDataObject = {
+		title: { type: 'title', title: { value: title } },
+	};
+
+	if (additionalFields.propertiesToSend?.property) {
+		for (const prop of additionalFields.propertiesToSend.property) {
+			if (prop.id) {
+				properties[prop.id] = mapUiPropertyToApi(prop);
+			}
+		}
+	}
+
+	const extraProperties = parseJsonField(
+		additionalFields.propertiesJson,
+		'Properties',
+		node,
+		itemIndex,
+	);
+	if (extraProperties) {
+		Object.assign(properties, extraProperties);
+	}
+
+	const body: IDataObject = { structureId, properties };
+
+	const collectionIds = (additionalFields.collectionIds ?? '')
+		.split(',')
+		.map((id) => id.trim())
+		.filter(Boolean);
+	if (collectionIds.length) {
+		body.collections = collectionIds;
+	}
+
+	const blocks = parseJsonField(additionalFields.blocksJson, 'Blocks', node, itemIndex);
+	if (blocks) {
+		body.blocks = blocks;
+	}
+
+	return body;
+}
+
 export class CapacitiesV2 implements INodeType {
 	methods = {
 		loadOptions: {
@@ -116,98 +271,84 @@ export class CapacitiesV2 implements INodeType {
 				'Content-Type': 'application/json',
 			},
 		},
-		properties: [...resources, ...space, ...search, ...weblink, ...dailyNote, ...tag, ...general],
+		properties: [
+			...resources,
+			...space,
+			...search,
+			...weblink,
+			...dailyNote,
+			...tag,
+			...object,
+			...general,
+		],
 	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const returnData: INodeExecutionData[] = [];
 
+		const credentials = await this.getCredentials('capacitiesApi');
+		const token = credentials.token as string;
+		const client = new CapacitiesClient({ apiToken: token });
+
 		for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
 			const resource = this.getNodeParameter('resource', itemIndex) as string;
 			const operation = this.getNodeParameter('operation', itemIndex) as string;
-			let requestOptions: RequestOptions;
+			let response: any;
 			let rootProperty: string | undefined;
 
-			if (resource === 'space' && operation === 'get') {
-				requestOptions = {
-					method: 'GET',
-					baseURL: 'https://api.capacities.io',
-					url: '/space',
-					json: true,
-				};
-			} else if (resource === 'space' && operation === 'getInfo') {
-				requestOptions = {
-					method: 'GET',
-					baseURL: 'https://api.capacities.io',
-					url: '/space/structures',
-					json: true,
-				};
-				rootProperty = 'structures';
-			} else if (resource === 'search' && operation === 'search') {
-				const structureIds = this.getNodeParameter('structureIds', itemIndex, []) as string[];
-				const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
-				const body: IDataObject = {
-					query: this.getNodeParameter('searchTerm', itemIndex) as string,
-					limit,
-				};
+			try {
+				if (resource === 'space' && operation === 'get') {
+					response = await client.space.get();
+				} else if (resource === 'space' && operation === 'getInfo') {
+					response = await client.space.structures();
+					rootProperty = 'structures';
+				} else if (resource === 'search' && operation === 'search') {
+					const structureIds = this.getNodeParameter('structureIds', itemIndex, []) as string[];
+					const limit = this.getNodeParameter('limit', itemIndex, 50) as number;
+					const body: any = {
+						query: this.getNodeParameter('searchTerm', itemIndex) as string,
+						limit,
+					};
 
-				if (structureIds.length) {
-					body.structureIds = structureIds;
-				}
+					if (structureIds.length) {
+						body.structureIds = structureIds;
+					}
 
-				requestOptions = {
-					method: 'POST',
-					baseURL: 'https://api.capacities.io',
-					url: '/objects/search',
-					json: true,
-					body,
-				};
-				rootProperty = 'results';
-			} else if (resource === 'weblink' && operation === 'save') {
-				const weblinkOptions = this.getNodeParameter(
-					'weblinkOptions',
-					itemIndex,
-					{},
-				) as WeblinkOptions;
-				if (getSelectedIds(weblinkOptions.tagIds).length) {
-					throw new NodeOperationError(this.getNode(), WEBLINK_TAGS_UNSUPPORTED_MESSAGE, {
+					response = await client.objects.search(body);
+					rootProperty = 'results';
+				} else if (resource === 'weblink' && operation === 'save') {
+					const weblinkOptions = this.getNodeParameter(
+						'weblinkOptions',
 						itemIndex,
-					});
-				}
+						{},
+					) as WeblinkOptions;
+					if (getSelectedIds(weblinkOptions.tagIds).length) {
+						throw new NodeOperationError(this.getNode(), WEBLINK_TAGS_UNSUPPORTED_MESSAGE, {
+							itemIndex,
+						});
+					}
 
-				requestOptions = {
-					method: 'POST',
-					baseURL: 'https://api.capacities.io',
-					url: '/object/url',
-					json: true,
-					body: getWeblinkBody(this.getNodeParameter('url', itemIndex) as string, weblinkOptions),
-				};
-			} else if (resource === 'dailyNote' && operation === 'saveToDailyNote') {
-				const body: IDataObject = {
-					markdown: this.getNodeParameter('mdText', itemIndex) as string,
-					noTimeStamp: !(this.getNodeParameter('timestamp', itemIndex, true) as boolean),
-				};
+					response = await client.object.createFromUrl(
+						getWeblinkBody(
+							this.getNodeParameter('url', itemIndex) as string,
+							weblinkOptions,
+						) as any,
+					);
+				} else if (resource === 'dailyNote' && operation === 'saveToDailyNote') {
+					const body: any = {
+						markdown: this.getNodeParameter('mdText', itemIndex) as string,
+						noTimeStamp: !(this.getNodeParameter('timestamp', itemIndex, true) as boolean),
+					};
 
-				const date = this.getNodeParameter('date', itemIndex, '') as string;
-				if (date) {
-					body.date = date;
-				}
+					const date = this.getNodeParameter('date', itemIndex, '') as string;
+					if (date) {
+						body.date = date;
+					}
 
-				requestOptions = {
-					method: 'POST',
-					baseURL: 'https://api.capacities.io',
-					url: '/blocks/daily-note/append',
-					json: true,
-					body,
-				};
-			} else if (resource === 'tag' && operation === 'save') {
-				requestOptions = {
-					method: 'POST',
-					baseURL: 'https://api.capacities.io',
-					url: '/object',
-					json: true,
-					body: {
+					response = await client.blocks.dailyNote.append(body);
+				} else if (resource === 'tag' && operation === 'save') {
+					response = await client.object.create({
 						structureId: 'RootTag',
 						properties: {
 							title: {
@@ -217,24 +358,109 @@ export class CapacitiesV2 implements INodeType {
 								},
 							},
 						},
-					},
-				};
-			} else {
-				throw new NodeOperationError(
-					this.getNode(),
-					`Unsupported Capacities operation: ${resource}.${operation}`,
-				);
+					});
+				} else if (resource === 'object' && operation === 'create') {
+					const structureId = this.getNodeParameter('structureId', itemIndex) as string;
+					const title = this.getNodeParameter('title', itemIndex) as string;
+					const additionalFields = this.getNodeParameter(
+						'additionalFields',
+						itemIndex,
+						{},
+					) as ObjectAdditionalFields;
+
+					response = await client.object.create(
+						getCreateObjectBody(
+							structureId,
+							title,
+							additionalFields,
+							this.getNode(),
+							itemIndex,
+						) as any,
+					);
+				} else if (resource === 'object' && operation === 'update') {
+					const id = this.getNodeParameter('id', itemIndex) as string;
+					const updateFields = this.getNodeParameter('updateFields', itemIndex, {}) as {
+						title?: string;
+						propertiesJson?: string;
+						collectionIds?: string;
+						blocksJson?: string;
+						propertiesToSend?: {
+							property?: Array<{
+								id: string;
+								type: string;
+								value: string;
+							}>;
+						};
+					};
+
+					const properties: IDataObject = {};
+					if (updateFields.title) {
+						properties.title = {
+							type: 'title',
+							title: { value: updateFields.title },
+						};
+					}
+
+					if (updateFields.propertiesToSend?.property) {
+						for (const prop of updateFields.propertiesToSend.property) {
+							if (prop.id) {
+								properties[prop.id] = mapUiPropertyToApi(prop);
+							}
+						}
+					}
+
+					const extraProperties = parseJsonField(
+						updateFields.propertiesJson,
+						'Properties',
+						this.getNode(),
+						itemIndex,
+					);
+					if (extraProperties) {
+						Object.assign(properties, extraProperties);
+					}
+
+					const body: any = { id };
+					if (Object.keys(properties).length) {
+						body.properties = properties;
+					}
+
+					const collectionIds = (updateFields.collectionIds ?? '')
+						.split(',')
+						.map((cid) => cid.trim())
+						.filter(Boolean);
+					if (collectionIds.length) {
+						body.collections = collectionIds;
+					}
+
+					const blocks = parseJsonField(
+						updateFields.blocksJson,
+						'Blocks',
+						this.getNode(),
+						itemIndex,
+					);
+					if (blocks) {
+						body.blocks = blocks;
+					}
+
+					response = await client.object.update(body);
+				} else if (resource === 'object' && operation === 'delete') {
+					const id = this.getNodeParameter('id', itemIndex) as string;
+					const hardDelete = this.getNodeParameter('hardDelete', itemIndex, false) as boolean;
+
+					response = await client.object.delete({ id, hardDelete });
+				} else {
+					throw new NodeOperationError(
+						this.getNode(),
+						`Unsupported Capacities operation: ${resource}.${operation}`,
+					);
+				}
+
+				returnData.push(...toJsonItems(response, rootProperty));
+			} catch (error) {
+				throw new NodeOperationError(this.getNode(), error as Error, {
+					itemIndex,
+				});
 			}
-
-			const response = await this.helpers.requestWithAuthentication.call(
-				this,
-				'capacitiesApi',
-				requestOptions,
-				undefined,
-				itemIndex,
-			);
-
-			returnData.push(...toJsonItems(response, rootProperty));
 		}
 
 		return [returnData];

--- a/nodes/Capacities/V2/DailyNoteDescription.ts
+++ b/nodes/Capacities/V2/DailyNoteDescription.ts
@@ -12,7 +12,7 @@ export const dailyNote: INodeProperties[] = [
 			{
 				name: 'Save',
 				value: 'saveToDailyNote',
-				description: "Append markdown to a daily note",
+				description: 'Append markdown to a daily note',
 				routing: {
 					request: {
 						url: '/blocks/daily-note/append',

--- a/nodes/Capacities/V2/GeneralFunctions.ts
+++ b/nodes/Capacities/V2/GeneralFunctions.ts
@@ -1,4 +1,5 @@
 import type { ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
+import { CapacitiesClient } from '@capacities/api';
 
 const CAPACITIES_RATE_LIMIT_MESSAGE =
 	'Capacities is receiving too many requests from this API token. Please wait a moment and try loading the options again.';
@@ -21,12 +22,14 @@ function getErrorStatusCode(error: unknown): number | undefined {
 	}
 
 	const errorObject = error as {
+		status?: number;
 		httpCode?: number;
 		statusCode?: number;
 		response?: { statusCode?: number; status?: number };
 	};
 
 	return (
+		errorObject.status ??
 		errorObject.httpCode ??
 		errorObject.statusCode ??
 		errorObject.response?.statusCode ??
@@ -47,20 +50,18 @@ function throwHumanReadableLoadOptionsError(error: unknown): never {
 }
 
 export async function loadStructures(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-	let response: { structures: Array<{ id: string; title: string }> };
+	let response: any;
 
 	try {
-		response = (await this.helpers.requestWithAuthentication.call(this, 'capacitiesApi', {
-			method: 'GET',
-			baseURL: 'https://api.capacities.io',
-			url: '/space/structures',
-			json: true,
-		})) as { structures: Array<{ id: string; title: string }> };
+		const credentials = await this.getCredentials('capacitiesApi');
+		const token = credentials.token as string;
+		const client = new CapacitiesClient({ apiToken: token });
+		response = await client.space.structures();
 	} catch (error) {
 		throwHumanReadableLoadOptionsError(error);
 	}
 
-	return response.structures
+	return (response.structures as Array<{ id: string; title: string }>)
 		.map((structure) => ({ name: structure.title, value: structure.id }))
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -70,24 +71,20 @@ export async function loadTags(this: ILoadOptionsFunctions): Promise<INodeProper
 	const queries = 'abcdefghijklmnopqrstuvwxyz'.split('');
 
 	try {
+		const credentials = await this.getCredentials('capacitiesApi');
+		const token = credentials.token as string;
+		const client = new CapacitiesClient({ apiToken: token });
+
 		await Promise.all(
 			queries.map(async (query) => {
-				const response = (await this.helpers.requestWithAuthentication.call(this, 'capacitiesApi', {
-					method: 'POST',
-					baseURL: 'https://api.capacities.io',
-					url: '/objects/search',
-					json: true,
-					body: {
-						query,
-						structureIds: ['RootTag'],
-						limit: 50,
-					},
-				})) as {
-					results: Array<{ id: string; title: string }>;
-				};
+				const response = await client.objects.search({
+					query,
+					structureIds: ['RootTag'],
+					limit: 50,
+				});
 
-				for (const tag of response.results) {
-					tagById.set(tag.id, tag.title);
+				for (const tag of response.results as any[]) {
+					tagById.set(tag.id as string, tag.title as string);
 				}
 			}),
 		);

--- a/nodes/Capacities/V2/ObjectDescription.ts
+++ b/nodes/Capacities/V2/ObjectDescription.ts
@@ -1,0 +1,301 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const object: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		required: true,
+		default: 'create',
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create an object of any structure/type',
+				action: 'Create an object',
+				routing: {
+					request: {
+						url: '/object',
+						method: 'POST',
+						json: true,
+						body: {
+							structureId: '={{$parameter.structureId}}',
+							properties:
+								'={{Object.assign({ title: { type: "title", title: { value: $parameter.title } } }, $parameter["additionalFields"]["propertiesJson"] ? JSON.parse($parameter["additionalFields"]["propertiesJson"]) : {})}}',
+							collections:
+								'={{$parameter["additionalFields"]["collectionIds"] ? $parameter["additionalFields"]["collectionIds"].split(",").map((id) => id.trim()).filter((id) => id) : undefined}}',
+							blocks:
+								'={{$parameter["additionalFields"]["blocksJson"] ? JSON.parse($parameter["additionalFields"]["blocksJson"]) : undefined}}',
+						},
+					},
+				},
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete an object from your space',
+				action: 'Delete an object',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update properties, collections, or blocks of an object',
+				action: 'Update an object',
+			},
+		],
+		displayOptions: {
+			show: {
+				resource: ['object'],
+			},
+		},
+	},
+	{
+		displayName: 'Structure Name or ID',
+		name: 'structureId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'loadStructures',
+		},
+		default: '',
+		required: true,
+		description:
+			'The structure (object type) to create the object as. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['create'],
+			},
+		},
+	},
+	{
+		displayName: 'Title',
+		name: 'title',
+		type: 'string',
+		description: 'The title of the object to create',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['create'],
+			},
+		},
+	},
+	{
+		displayName: 'Object ID',
+		name: 'id',
+		type: 'string',
+		default: '',
+		required: true,
+		description: 'The ID of the object to update or delete',
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['update', 'delete'],
+			},
+		},
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		placeholder: 'Add Field',
+		type: 'collection',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['create'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Blocks (JSON)',
+				name: 'blocksJson',
+				type: 'json',
+				default: '{}',
+				description:
+					'Initial block content, keyed by property definition ID. See the <a href="https://developers.capacities.io/api/concepts/objects">Capacities API docs</a> for the block model.',
+			},
+			{
+				displayName: 'Collection IDs',
+				name: 'collectionIds',
+				type: 'string',
+				default: '',
+				description: 'Comma-separated list of collection IDs to place the object into',
+			},
+			{
+				displayName: 'Properties (JSON)',
+				name: 'propertiesJson',
+				type: 'json',
+				default: '{}',
+				description:
+					'Additional typed properties to set, keyed by property definition ID. Merged with the title property. See the <a href="https://developers.capacities.io/api/concepts/properties">Capacities API docs</a> for the typed value shapes.',
+			},
+			{
+				displayName: 'Properties to Send',
+				name: 'propertiesToSend',
+				placeholder: 'Add Property',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				description: 'Custom properties to set without writing raw JSON',
+				options: [
+					{
+						name: 'property',
+						displayName: 'Property',
+						values: [
+							{
+								displayName: 'Property ID',
+								name: 'id',
+								type: 'string',
+								required: true,
+								default: '',
+								description:
+									'Stable key used in object properties maps (e.g. title, or a UUID for custom fields)',
+							},
+							{
+								displayName: 'Type',
+								name: 'type',
+								type: 'options',
+								options: [
+									{ name: 'Boolean', value: 'boolean' },
+									{ name: 'Date', value: 'date' },
+									{ name: 'Label / Select (Comma-Separated IDs)', value: 'label' },
+									{ name: 'Number', value: 'number' },
+									{ name: 'Reference / Link to Object (Comma-Separated IDs)', value: 'entity' },
+									{ name: 'Text / String', value: 'text' },
+									{ name: 'Title', value: 'title' },
+									{ name: 'URL', value: 'url' },
+								],
+								default: 'text',
+								description: 'The type of the property value',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description:
+									'The value to set (use true/false for Boolean, numbers for Number, ISO strings for Date)',
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		placeholder: 'Add Field',
+		type: 'collection',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Blocks (JSON)',
+				name: 'blocksJson',
+				type: 'json',
+				default: '{}',
+				description:
+					'Updated block content, keyed by property definition ID. See the <a href="https://developers.capacities.io/api/concepts/objects">Capacities API docs</a> for the block model.',
+			},
+			{
+				displayName: 'Collection IDs',
+				name: 'collectionIds',
+				type: 'string',
+				default: '',
+				description: 'Comma-separated list of collection IDs to place the object into',
+			},
+			{
+				displayName: 'Properties (JSON)',
+				name: 'propertiesJson',
+				type: 'json',
+				default: '{}',
+				description:
+					'Additional typed properties to set, keyed by property definition ID. Merged with the title property. See the <a href="https://developers.capacities.io/api/concepts/properties">Capacities API docs</a> for the typed value shapes.',
+			},
+			{
+				displayName: 'Properties to Send',
+				name: 'propertiesToSend',
+				placeholder: 'Add Property',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				description: 'Custom properties to update without writing raw JSON',
+				options: [
+					{
+						name: 'property',
+						displayName: 'Property',
+						values: [
+							{
+								displayName: 'Property ID',
+								name: 'id',
+								type: 'string',
+								required: true,
+								default: '',
+								description:
+									'Stable key used in object properties maps (e.g. title, or a UUID for custom fields)',
+							},
+							{
+								displayName: 'Type',
+								name: 'type',
+								type: 'options',
+								options: [
+									{ name: 'Boolean', value: 'boolean' },
+									{ name: 'Date', value: 'date' },
+									{ name: 'Label / Select (Comma-Separated IDs)', value: 'label' },
+									{ name: 'Number', value: 'number' },
+									{ name: 'Reference / Link to Object (Comma-Separated IDs)', value: 'entity' },
+									{ name: 'Text / String', value: 'text' },
+									{ name: 'Title', value: 'title' },
+									{ name: 'URL', value: 'url' },
+								],
+								default: 'text',
+								description: 'The type of the property value',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description:
+									'The value to set (use true/false for Boolean, numbers for Number, ISO strings for Date)',
+							},
+						],
+					},
+				],
+			},
+			{
+				displayName: 'Title',
+				name: 'title',
+				type: 'string',
+				default: '',
+				description: 'The new title of the object',
+			},
+		],
+	},
+	{
+		displayName: 'Hard Delete',
+		name: 'hardDelete',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to permanently delete the object, bypassing the trash',
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['delete'],
+			},
+		},
+	},
+];

--- a/nodes/Capacities/V2/ResourceDescription.ts
+++ b/nodes/Capacities/V2/ResourceDescription.ts
@@ -12,6 +12,10 @@ export const resources: INodeProperties[] = [
 				value: 'dailyNote',
 			},
 			{
+				name: 'Object',
+				value: 'object',
+			},
+			{
 				name: 'Search',
 				value: 'search',
 			},

--- a/nodes/Capacities/V2/SpaceDescription.ts
+++ b/nodes/Capacities/V2/SpaceDescription.ts
@@ -25,8 +25,7 @@ export const space: INodeProperties[] = [
 				name: 'Get Info',
 				value: 'getInfo',
 				action: 'Get structures and collections of the space',
-				description:
-					'Returns object types, property definitions, and collections for the space',
+				description: 'Returns object types, property definitions, and collections for the space',
 				routing: {
 					request: {
 						url: '/space/structures',

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -3,7 +3,47 @@ import type { IExecuteFunctions } from 'n8n-workflow';
 import { CapacitiesV2 } from '../CapacitiesV2.node';
 import { getOptions, getProperty } from './testUtils';
 
+const mockSpaceGet = jest.fn();
+const mockSpaceStructures = jest.fn();
+const mockObjectsSearch = jest.fn();
+const mockObjectCreate = jest.fn();
+const mockObjectUpdate = jest.fn();
+const mockObjectDelete = jest.fn();
+const mockObjectCreateFromUrl = jest.fn();
+const mockBlocksDailyNoteAppend = jest.fn();
+
+jest.mock('@capacities/api', () => {
+	return {
+		CapacitiesClient: jest.fn().mockImplementation(() => {
+			return {
+				space: {
+					get: mockSpaceGet,
+					structures: mockSpaceStructures,
+				},
+				objects: {
+					search: mockObjectsSearch,
+				},
+				object: {
+					create: mockObjectCreate,
+					update: mockObjectUpdate,
+					delete: mockObjectDelete,
+					createFromUrl: mockObjectCreateFromUrl,
+				},
+				blocks: {
+					dailyNote: {
+						append: mockBlocksDailyNoteAppend,
+					},
+				},
+			};
+		}),
+	};
+});
+
 describe('CapacitiesV2 node', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	it('exposes Capacities API defaults', () => {
 		const node = new CapacitiesV2();
 		expect(node.description.version).toBe(2);
@@ -24,7 +64,7 @@ describe('CapacitiesV2 node', () => {
 			getOptions(resourceProperty)
 				.map((option) => option.value)
 				.sort(),
-		).toEqual(['dailyNote', 'search', 'space', 'tag', 'weblink']);
+		).toEqual(['dailyNote', 'object', 'search', 'space', 'tag', 'weblink']);
 	});
 
 	it('registers load option helpers', () => {
@@ -35,7 +75,7 @@ describe('CapacitiesV2 node', () => {
 
 	it('saves weblinks with supported properties', async () => {
 		const node = new CapacitiesV2();
-		const requestMock = jest.fn().mockResolvedValue({ id: 'created-weblink' });
+		mockObjectCreateFromUrl.mockResolvedValue({ id: 'created-weblink' });
 		const context = {
 			getInputData: jest.fn(() => [{ json: {} }]),
 			getNodeParameter: jest.fn((parameterName: string) => {
@@ -52,43 +92,132 @@ describe('CapacitiesV2 node', () => {
 
 				return parameters[parameterName];
 			}),
-			helpers: {
-				requestWithAuthentication: requestMock,
-			},
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
 		} as unknown as IExecuteFunctions;
 
 		const result = await node.execute.call(context);
 
-		expect(requestMock).toHaveBeenCalledTimes(1);
-		expect(requestMock).toHaveBeenCalledWith(
-			'capacitiesApi',
-			expect.objectContaining({
-				url: '/object/url',
-				method: 'POST',
-				body: {
-					url: 'https://example.com',
-					markdown: 'Notes',
-					properties: {
-						title: {
-							type: 'title',
-							title: { value: 'Title' },
-						},
-						description: {
-							type: 'text',
-							text: { value: 'Description' },
-						},
-					},
+		expect(mockObjectCreateFromUrl).toHaveBeenCalledTimes(1);
+		expect(mockObjectCreateFromUrl).toHaveBeenCalledWith({
+			url: 'https://example.com',
+			markdown: 'Notes',
+			properties: {
+				title: {
+					type: 'title',
+					title: { value: 'Title' },
 				},
-			}),
-			undefined,
-			0,
-		);
+				description: {
+					type: 'text',
+					text: { value: 'Description' },
+				},
+			},
+		});
 		expect(result).toEqual([[{ json: { id: 'created-weblink' } }]]);
+	});
+
+	it('creates objects with just a title', async () => {
+		const node = new CapacitiesV2();
+		mockObjectCreate.mockResolvedValue({ id: 'created-object' });
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'create',
+					structureId: 'structure-1',
+					title: 'My Object',
+					additionalFields: {},
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		const result = await node.execute.call(context);
+
+		expect(mockObjectCreate).toHaveBeenCalledWith({
+			structureId: 'structure-1',
+			properties: {
+				title: { type: 'title', title: { value: 'My Object' } },
+			},
+		});
+		expect(result).toEqual([[{ json: { id: 'created-object' } }]]);
+	});
+
+	it('creates objects with additional properties, collections, and blocks', async () => {
+		const node = new CapacitiesV2();
+		mockObjectCreate.mockResolvedValue({ id: 'created-object' });
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'create',
+					structureId: 'structure-1',
+					title: 'My Object',
+					additionalFields: {
+						propertiesJson: '{"score":{"type":"number","number":{"value":42}}}',
+						collectionIds: ' collection-1 , collection-2 ,,',
+						blocksJson:
+							'{"notes":[{"type":"TextBlock","tokens":[{"type":"TextToken","text":"Hi","style":{}}]}]}',
+					},
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		await node.execute.call(context);
+
+		expect(mockObjectCreate).toHaveBeenCalledWith({
+			structureId: 'structure-1',
+			properties: {
+				title: { type: 'title', title: { value: 'My Object' } },
+				score: { type: 'number', number: { value: 42 } },
+			},
+			collections: ['collection-1', 'collection-2'],
+			blocks: {
+				notes: [
+					{
+						type: 'TextBlock',
+						tokens: [{ type: 'TextToken', text: 'Hi', style: {} }],
+					},
+				],
+			},
+		});
+	});
+
+	it('fails clearly with invalid JSON in the object properties field', async () => {
+		const node = new CapacitiesV2();
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'create',
+					structureId: 'structure-1',
+					title: 'My Object',
+					additionalFields: {
+						propertiesJson: '{bad',
+					},
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		await expect(node.execute.call(context)).rejects.toThrow('Invalid JSON in Properties');
+		expect(mockObjectCreate).not.toHaveBeenCalled();
 	});
 
 	it('fails clearly when stale workflows still contain selected weblink tags', async () => {
 		const node = new CapacitiesV2();
-		const requestMock = jest.fn();
 		const context = {
 			getInputData: jest.fn(() => [{ json: {} }]),
 			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
@@ -104,14 +233,178 @@ describe('CapacitiesV2 node', () => {
 
 				return parameters[parameterName];
 			}),
-			helpers: {
-				requestWithAuthentication: requestMock,
-			},
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
 		} as unknown as IExecuteFunctions;
 
 		await expect(node.execute.call(context)).rejects.toThrow(
 			'Capacities API does not currently support assigning tags to weblinks',
 		);
-		expect(requestMock).not.toHaveBeenCalled();
+		expect(mockObjectCreateFromUrl).not.toHaveBeenCalled();
+	});
+
+	it('updates objects with optional properties, collections, and blocks', async () => {
+		const node = new CapacitiesV2();
+		mockObjectUpdate.mockResolvedValue({ id: 'updated-object' });
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'update',
+					id: 'object-id-123',
+					updateFields: {
+						title: 'New Title',
+						propertiesJson: '{"score":{"type":"number","number":{"value":43}}}',
+						collectionIds: ' collection-1 , collection-3 ',
+						blocksJson:
+							'{"notes":[{"type":"TextBlock","tokens":[{"type":"TextToken","text":"Updated","style":{}}]}]}',
+					},
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		const result = await node.execute.call(context);
+
+		expect(mockObjectUpdate).toHaveBeenCalledWith({
+			id: 'object-id-123',
+			properties: {
+				title: { type: 'title', title: { value: 'New Title' } },
+				score: { type: 'number', number: { value: 43 } },
+			},
+			collections: ['collection-1', 'collection-3'],
+			blocks: {
+				notes: [
+					{
+						type: 'TextBlock',
+						tokens: [{ type: 'TextToken', text: 'Updated', style: {} }],
+					},
+				],
+			},
+		});
+		expect(result).toEqual([[{ json: { id: 'updated-object' } }]]);
+	});
+
+	it('deletes objects', async () => {
+		const node = new CapacitiesV2();
+		mockObjectDelete.mockResolvedValue(undefined);
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'delete',
+					id: 'object-id-123',
+					hardDelete: true,
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		const result = await node.execute.call(context);
+
+		expect(mockObjectDelete).toHaveBeenCalledWith({
+			id: 'object-id-123',
+			hardDelete: true,
+		});
+		expect(result).toEqual([[{ json: {} }]]);
+	});
+
+	it('creates and updates objects with mapped propertiesToSend', async () => {
+		const node = new CapacitiesV2();
+		mockObjectCreate.mockResolvedValue({ id: 'created-object' });
+
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'create',
+					structureId: 'structure-1',
+					title: 'My Object',
+					additionalFields: {
+						propertiesToSend: {
+							property: [
+								{ id: 'author', type: 'text', value: 'Christian Münch' },
+								{ id: 'age', type: 'number', value: '42' },
+								{ id: 'is_active', type: 'boolean', value: 'true' },
+								{ id: 'website', type: 'url', value: 'https://example.com' },
+								{ id: 'birthday', type: 'date', value: '2026-08-13' },
+								{ id: 'tags', type: 'label', value: 'tag-1, tag-2' },
+								{ id: 'links', type: 'entity', value: 'ent-1, ent-2' },
+							],
+						},
+					},
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		await node.execute.call(context);
+
+		expect(mockObjectCreate).toHaveBeenCalledWith({
+			structureId: 'structure-1',
+			properties: {
+				title: { type: 'title', title: { value: 'My Object' } },
+				author: { type: 'text', text: { value: 'Christian Münch' } },
+				age: { type: 'number', number: { value: 42 } },
+				is_active: { type: 'boolean', boolean: { value: true } },
+				website: { type: 'url', url: { value: 'https://example.com' } },
+				birthday: { type: 'date', date: { start: '2026-08-13' } },
+				tags: { type: 'label', label: [{ id: 'tag-1' }, { id: 'tag-2' }] },
+				links: { type: 'entity', entity: [{ id: 'ent-1' }, { id: 'ent-2' }] },
+			},
+		});
+	});
+
+	it('handles native arrays, JSON arrays, and array of objects for entity/label properties', async () => {
+		const node = new CapacitiesV2();
+		mockObjectCreate.mockResolvedValue({ id: 'created-object' });
+
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'create',
+					structureId: 'structure-1',
+					title: 'My Object',
+					additionalFields: {
+						propertiesToSend: {
+							property: [
+								{ id: 'tags1', type: 'label', value: ['tag-1', 'tag-2'] },
+								{ id: 'tags2', type: 'label', value: '["tag-3", "tag-4"]' },
+								{ id: 'tags3', type: 'label', value: [{ id: 'tag-5' }, { id: 'tag-6' }] },
+							],
+						},
+					},
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		await node.execute.call(context);
+
+		expect(mockObjectCreate).toHaveBeenCalledWith({
+			structureId: 'structure-1',
+			properties: {
+				title: { type: 'title', title: { value: 'My Object' } },
+				tags1: { type: 'label', label: [{ id: 'tag-1' }, { id: 'tag-2' }] },
+				tags2: { type: 'label', label: [{ id: 'tag-3' }, { id: 'tag-4' }] },
+				tags3: { type: 'label', label: [{ id: 'tag-5' }, { id: 'tag-6' }] },
+			},
+		});
 	});
 });

--- a/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
+++ b/nodes/Capacities/V2/__tests__/GeneralFunctions.test.ts
@@ -1,52 +1,53 @@
 import type { ILoadOptionsFunctions } from 'n8n-workflow';
-
 import { loadStructures, loadTags } from '../GeneralFunctions';
+
+const mockSpaceStructures = jest.fn();
+const mockObjectsSearch = jest.fn();
+
+jest.mock('@capacities/api', () => {
+	return {
+		CapacitiesClient: jest.fn().mockImplementation(() => {
+			return {
+				space: {
+					structures: mockSpaceStructures,
+				},
+				objects: {
+					search: mockObjectsSearch,
+				},
+			};
+		}),
+	};
+});
 
 const rateLimitMessage =
 	'Capacities is receiving too many requests from this API token. Please wait a moment and try loading the options again.';
 
-const createContext = (response: Record<string, unknown>) => {
-	const requestMock = jest.fn().mockResolvedValue(response);
+const createContext = () => {
 	const context = {
-		helpers: {
-			requestWithAuthentication: requestMock,
-		},
+		getCredentials: jest.fn().mockResolvedValue({ token: 'test-token' }),
 	} as unknown as ILoadOptionsFunctions;
 
-	return { context, requestMock };
-};
-
-const createRejectingContext = (error: unknown) => {
-	const requestMock = jest.fn().mockRejectedValue(error);
-	const context = {
-		helpers: {
-			requestWithAuthentication: requestMock,
-		},
-	} as unknown as ILoadOptionsFunctions;
-
-	return { context, requestMock };
+	return { context };
 };
 
 describe('loadStructures helper (v1)', () => {
-	it('requests GET /space/structures with no spaceId and maps id/title pairs', async () => {
-		const { context, requestMock } = createContext({
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('requests structures and maps id/title pairs', async () => {
+		mockSpaceStructures.mockResolvedValue({
 			structures: [
 				{ id: 'structure-b', title: 'Beta' },
 				{ id: 'structure-a', title: 'Alpha' },
 			],
 		});
 
+		const { context } = createContext();
 		const result = await loadStructures.call(context);
 
-		expect(requestMock).toHaveBeenCalledTimes(1);
-		expect(requestMock).toHaveBeenCalledWith(
-			'capacitiesApi',
-			expect.objectContaining({
-				url: '/space/structures',
-				method: 'GET',
-			}),
-		);
-		expect(requestMock.mock.calls[0][1]).not.toHaveProperty('qs');
+		expect(mockSpaceStructures).toHaveBeenCalledTimes(1);
+		expect(context.getCredentials).toHaveBeenCalledWith('capacitiesApi');
 		expect(result).toEqual([
 			{ name: 'Alpha', value: 'structure-a' },
 			{ name: 'Beta', value: 'structure-b' },
@@ -54,18 +55,24 @@ describe('loadStructures helper (v1)', () => {
 	});
 
 	it('shows a human-readable rate-limit error', async () => {
-		const { context } = createRejectingContext({
-			response: { statusCode: 429 },
+		mockSpaceStructures.mockRejectedValue({
+			status: 429,
 			message: 'The service is receiving too many requests from you',
 		});
+
+		const { context } = createContext();
 
 		await expect(loadStructures.call(context)).rejects.toThrow(rateLimitMessage);
 	});
 });
 
 describe('loadTags helper (v2)', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	it('loads tag options from valid RootTag searches and deduplicates results', async () => {
-		const { context, requestMock } = createContext({
+		mockObjectsSearch.mockResolvedValue({
 			results: [
 				{ id: 'tag-b', title: 'Beta' },
 				{ id: 'tag-a', title: 'Alpha' },
@@ -73,21 +80,18 @@ describe('loadTags helper (v2)', () => {
 			],
 		});
 
+		const { context } = createContext();
 		const result = await loadTags.call(context);
 
-		expect(requestMock).toHaveBeenCalledTimes(26);
-		expect(requestMock).toHaveBeenCalledWith(
-			'capacitiesApi',
+		expect(mockObjectsSearch).toHaveBeenCalledTimes(26);
+		expect(mockObjectsSearch).toHaveBeenCalledWith(
 			expect.objectContaining({
-				url: '/objects/search',
-				method: 'POST',
-				body: {
-					query: 'a',
-					structureIds: ['RootTag'],
-					limit: 50,
-				},
+				query: 'a',
+				structureIds: ['RootTag'],
+				limit: 50,
 			}),
 		);
+		expect(context.getCredentials).toHaveBeenCalledWith('capacitiesApi');
 		expect(result).toEqual([
 			{ name: 'Alpha', value: 'tag-a' },
 			{ name: 'Beta', value: 'tag-b' },
@@ -95,9 +99,12 @@ describe('loadTags helper (v2)', () => {
 	});
 
 	it('shows a human-readable rate-limit error', async () => {
-		const { context } = createRejectingContext(
-			new Error('NodeApiError The service is receiving too many requests from you'),
-		);
+		mockObjectsSearch.mockRejectedValue({
+			status: 429,
+			message: 'The service is receiving too many requests from you',
+		});
+
+		const { context } = createContext();
 
 		await expect(loadTags.call(context)).rejects.toThrow(rateLimitMessage);
 	});

--- a/nodes/Capacities/V2/__tests__/ObjectDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/ObjectDescription.test.ts
@@ -1,0 +1,88 @@
+import { object } from '../ObjectDescription';
+import { getOptions, getProperty } from './testUtils';
+
+describe('Object description (v2)', () => {
+	it('creates objects with POST /object routing', () => {
+		const operationProperty = getProperty(object, 'operation', 'object');
+		expect(operationProperty).toBeDefined();
+		const createOption = getOptions(operationProperty).find((option) => option.value === 'create');
+
+		expect(createOption?.routing?.request).toMatchObject({
+			url: '/object',
+			method: 'POST',
+			json: true,
+			body: {
+				structureId: '={{$parameter.structureId}}',
+			},
+		});
+	});
+
+	it('exposes a structure selector backed by loadStructures', () => {
+		const structureProperty = getProperty(object, 'structureId', 'object');
+
+		expect(structureProperty).toMatchObject({
+			type: 'options',
+			required: true,
+			default: '',
+			typeOptions: {
+				loadOptionsMethod: 'loadStructures',
+			},
+		});
+	});
+
+	it('exposes a required title field', () => {
+		const titleProperty = getProperty(object, 'title', 'object');
+
+		expect(titleProperty).toMatchObject({
+			type: 'string',
+			required: true,
+			default: '',
+		});
+	});
+
+	it('exposes additional fields for properties, collections, and blocks', () => {
+		const additionalFieldsProperty = getProperty(object, 'additionalFields', 'object');
+
+		expect(additionalFieldsProperty).toMatchObject({
+			type: 'collection',
+			default: {},
+		});
+		expect(additionalFieldsProperty?.options?.map((option) => option.name).sort()).toEqual([
+			'blocksJson',
+			'collectionIds',
+			'propertiesJson',
+			'propertiesToSend',
+		]);
+	});
+
+	it('exposes update fields for title, properties, collections, and blocks', () => {
+		const updateFieldsProperty = getProperty(object, 'updateFields', 'object');
+
+		expect(updateFieldsProperty).toMatchObject({
+			type: 'collection',
+			default: {},
+		});
+		expect(updateFieldsProperty?.options?.map((option) => option.name).sort()).toEqual([
+			'blocksJson',
+			'collectionIds',
+			'propertiesJson',
+			'propertiesToSend',
+			'title',
+		]);
+	});
+
+	it('exposes fields for update/delete object operations', () => {
+		const idProperty = getProperty(object, 'id', 'object');
+		expect(idProperty).toMatchObject({
+			type: 'string',
+			required: true,
+			default: '',
+		});
+
+		const hardDeleteProperty = getProperty(object, 'hardDelete', 'object');
+		expect(hardDeleteProperty).toMatchObject({
+			type: 'boolean',
+			default: false,
+		});
+	});
+});

--- a/nodes/Capacities/V2/__tests__/ResourceDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/ResourceDescription.test.ts
@@ -6,12 +6,10 @@ describe('Resource description (v1)', () => {
 		const resourceProperty = getProperty(resources, 'resource');
 		expect(resourceProperty).toBeDefined();
 		expect(resourceProperty?.default).toBe('dailyNote');
-		expect(getOptions(resourceProperty).map((option) => option.value).sort()).toEqual([
-			'dailyNote',
-			'search',
-			'space',
-			'tag',
-			'weblink',
-		]);
+		expect(
+			getOptions(resourceProperty)
+				.map((option) => option.value)
+				.sort(),
+		).toEqual(['dailyNote', 'object', 'search', 'space', 'tag', 'weblink']);
 	});
 });

--- a/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/WeblinkDescription.test.ts
@@ -37,8 +37,7 @@ describe('Weblink description (v2)', () => {
 		const operationProperty = getProperty(weblink, 'operation', 'weblink');
 		const saveOption = getOptions(operationProperty).find((option) => option.value === 'save');
 		const body = saveOption?.routing?.request?.body as
-			| { markdown?: string; properties?: Record<string, string> }
-			| undefined;
+			{ markdown?: string; properties?: Record<string, string> } | undefined;
 
 		expect(body?.markdown).toContain('$parameter["weblinkOptions"]["markdown"]');
 		expect(body?.properties?.title).toContain('$parameter["weblinkOptions"]["titleOverwrite"]');
@@ -51,8 +50,7 @@ describe('Weblink description (v2)', () => {
 		const operationProperty = getProperty(weblink, 'operation', 'weblink');
 		const saveOption = getOptions(operationProperty).find((option) => option.value === 'save');
 		const body = saveOption?.routing?.request?.body as
-			| { properties?: { tags?: string } }
-			| undefined;
+			{ properties?: { tags?: string } } | undefined;
 
 		expect(body?.properties?.tags).toBeUndefined();
 	});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
       "dist/nodes/Capacities/Capacities.node.js"
     ]
   },
+  "dependencies": {
+    "@capacities/api": "^1.1.2",
+    "zod": "^4.4.3"
+  },
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "~26.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@capacities/api':
+        specifier: ^1.1.2
+        version: 1.1.2(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/jest':
         specifier: ^30.0.0
@@ -219,6 +226,12 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@capacities/api@1.1.2':
+    resolution: {integrity: sha512-YbooQplkZaHwyfhdYujLdv4GjHrjPr5vQgZM5ntFQBhibTNab3H62tLip5tKJkH6XRi8uWXs+XUi1A6wojjgLg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.23.0 || ^4.0.0
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -2237,6 +2250,9 @@ packages:
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@babel/code-frame@7.27.1':
@@ -2435,6 +2451,10 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@capacities/api@1.1.2(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4814,3 +4834,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.67: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
This PR migrates the Capacities V2 nodes to use the official `@capacities/api` SDK and implements the requested `update` and `delete` operations for the `object` resource. It also introduces the `propertiesToSend` collection parameter to easily map title, text, number, boolean, date, labels, and reference arrays via the UI. All test suites pass successfully.