### PR TITLE
Return result on object delete operation

### DIFF
--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -447,7 +447,8 @@ export class CapacitiesV2 implements INodeType {
 					const id = this.getNodeParameter('id', itemIndex) as string;
 					const hardDelete = this.getNodeParameter('hardDelete', itemIndex, false) as boolean;
 
-					response = await client.object.delete({ id, hardDelete });
+					await client.object.delete({ id, hardDelete });
+					response = { success: true };
 				} else {
 					throw new NodeOperationError(
 						this.getNode(),

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -313,7 +313,7 @@ describe('CapacitiesV2 node', () => {
 			id: 'object-id-123',
 			hardDelete: true,
 		});
-		expect(result).toEqual([[{ json: {} }]]);
+		expect(result).toEqual([[{ json: { success: true } }]]);
 	});
 
 	it('creates and updates objects with mapped propertiesToSend', async () => {


### PR DESCRIPTION
This pull request updates the object delete operation in V2 of the Capacities node to return `{ success: true }` instead of an empty result. This is useful for workflows to verify the deletion succeeded or continue downstream processing.

### Changes
- Changed V2 `delete` object response to assign `{ success: true }`.
- Updated unit tests to verify the success payload.