### PR TITLE
Add get object operation

### DIFF
--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -449,6 +449,10 @@ export class CapacitiesV2 implements INodeType {
 
 					await client.object.delete({ id, hardDelete });
 					response = { success: true };
+				} else if (resource === 'object' && operation === 'get') {
+					const id = this.getNodeParameter('id', itemIndex) as string;
+
+					response = await client.object.get({ id });
 				} else {
 					throw new NodeOperationError(
 						this.getNode(),

--- a/nodes/Capacities/V2/ObjectDescription.ts
+++ b/nodes/Capacities/V2/ObjectDescription.ts
@@ -38,6 +38,12 @@ export const object: INodeProperties[] = [
 				action: 'Delete an object',
 			},
 			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get an object from your space',
+				action: 'Get an object',
+			},
+			{
 				name: 'Update',
 				value: 'update',
 				description: 'Update properties, collections, or blocks of an object',
@@ -88,11 +94,11 @@ export const object: INodeProperties[] = [
 		type: 'string',
 		default: '',
 		required: true,
-		description: 'The ID of the object to update or delete',
+		description: 'The ID of the object to get, update, or delete',
 		displayOptions: {
 			show: {
 				resource: ['object'],
-				operation: ['update', 'delete'],
+				operation: ['get', 'update', 'delete'],
 			},
 		},
 	},

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -6,6 +6,7 @@ import { getOptions, getProperty } from './testUtils';
 const mockSpaceGet = jest.fn();
 const mockSpaceStructures = jest.fn();
 const mockObjectsSearch = jest.fn();
+const mockObjectGet = jest.fn();
 const mockObjectCreate = jest.fn();
 const mockObjectUpdate = jest.fn();
 const mockObjectDelete = jest.fn();
@@ -24,6 +25,7 @@ jest.mock('@capacities/api', () => {
 					search: mockObjectsSearch,
 				},
 				object: {
+					get: mockObjectGet,
 					create: mockObjectCreate,
 					update: mockObjectUpdate,
 					delete: mockObjectDelete,
@@ -406,5 +408,31 @@ describe('CapacitiesV2 node', () => {
 				tags3: { type: 'label', label: [{ id: 'tag-5' }, { id: 'tag-6' }] },
 			},
 		});
+	});
+
+	it('gets objects', async () => {
+		const node = new CapacitiesV2();
+		mockObjectGet.mockResolvedValue({ id: 'object-id-123', title: 'Test Object' });
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'get',
+					id: 'object-id-123',
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		const result = await node.execute.call(context);
+
+		expect(mockObjectGet).toHaveBeenCalledWith({
+			id: 'object-id-123',
+		});
+		expect(result).toEqual([[{ json: { id: 'object-id-123', title: 'Test Object' } }]]);
 	});
 });

--- a/nodes/Capacities/V2/__tests__/ObjectDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/ObjectDescription.test.ts
@@ -71,12 +71,30 @@ describe('Object description (v2)', () => {
 		]);
 	});
 
-	it('exposes fields for update/delete object operations', () => {
+	it('defines get object operation', () => {
+		const operationProperty = getProperty(object, 'operation', 'object');
+		expect(operationProperty).toBeDefined();
+		const getOption = getOptions(operationProperty).find((option) => option.value === 'get');
+		expect(getOption).toMatchObject({
+			name: 'Get',
+			value: 'get',
+			description: 'Get an object from your space',
+			action: 'Get an object',
+		});
+	});
+
+	it('exposes fields for get/update/delete object operations', () => {
 		const idProperty = getProperty(object, 'id', 'object');
 		expect(idProperty).toMatchObject({
 			type: 'string',
 			required: true,
 			default: '',
+			displayOptions: {
+				show: {
+					resource: ['object'],
+					operation: ['get', 'update', 'delete'],
+				},
+			},
 		});
 
 		const hardDeleteProperty = getProperty(object, 'hardDelete', 'object');


### PR DESCRIPTION
## Summary of Changes
This pull request adds the **Get Object** read operation to the V2 node. This allows fetching a simple object from a space by its ID via the official Capacities SDK.

### Added Features
- `Get` operation under the `object` resource.
- Support for the `Get` operation in the `Object ID` field.

### Modified Files
- `nodes/Capacities/V2/ObjectDescription.ts`: Exposed the "Get" operation and updated the display/description of the `id` parameter.
- `nodes/Capacities/V2/CapacitiesV2.node.ts`: Implemented the `execute` branch for the `get` operation using `client.object.get({ id })`.

## Verification Details
- Verified via unit tests (`pnpm test`).
- Verified style and formatting (`pnpm lint`, `pnpm format`).
- Confirmed that `dist/` is successfully rebuilt prior to merge.