### PR TITLE
Optimize label property saving and parser robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,58 @@ pnpm add @muench-dev/n8n-nodes-capacities
 ![images](.github/images/screenshot_20240616_174548.png)
 ![images](.github/images/screenshot_20240616_181848.png)
 
+## Mapping Label & Entity Properties
+
+When creating or updating objects, you can define label and entity properties using the **Properties to Send** section or within **Properties (JSON)**. The node dynamically parses several input formats:
+
+- **Comma-Separated IDs**: A list of IDs separated by a comma (e.g., `in-progress, done` maps to `[{ id: 'in-progress' }, { id: 'done' }]`).
+- **Single String ID**: A single ID (e.g., `in-progress` maps to `[{ id: 'in-progress' }]`).
+- **Array of IDs**: A JSON/native array of IDs (e.g., `["in-progress", "done"]` maps to `[{ id: 'in-progress' }, { id: 'done' }]`).
+- **Single Object (JSON or Native)**: A single object containing an `id` property (e.g., `{"id": "in-progress", "name": "In Progress"}` maps to `[{ id: 'in-progress' }]`).
+- **Nested Label/Entity Output (Direct Mapping)**: A fully qualified property structure mapped from another Capacities node output (e.g., `{"type": "label", "label": [{"id": "in-progress"}]}` maps to `[{ id: 'in-progress' }]`).
+
+### Example: Creating a Task
+
+To create a new Task in Capacities (structure ID `RootTask`):
+
+1. **Set Structure**: Choose or specify `RootTask` as the **Structure Name or ID**.
+2. **Set Title**: Enter the task's title.
+3. **Configure Properties (under Additional Fields → Properties to Send)**:
+   - **Date** (e.g., when the task was scheduled):
+     - **Property ID**: `date`
+     - **Type**: `Date`
+     - **Value**: `2026-08-13T10:25:37.585Z` (automatically parses to time resolution)
+   - **Priority**:
+     - **Property ID**: `priority`
+     - **Type**: `Label / Select`
+     - **Value**: `medium` (automatically maps to option with ID `medium` and fallback name `medium`) or `{"id": "medium", "name": "Medium"}` to explicitly provide the display name.
+
+Alternatively, you can define all properties using **Properties (JSON)**:
+
+```json
+{
+  "date": {
+    "type": "date",
+    "date": {
+      "dateResolution": "time",
+      "start": "2026-08-13T10:25:37.585Z",
+      "end": null
+    }
+  },
+  "priority": {
+    "type": "label",
+    "label": [
+      {
+        "id": "medium",
+        "name": "Medium"
+      }
+    ]
+  }
+}
+```
+
+---
+
 ## Development
 
 1. Install dependencies using pnpm (recommended for this repository):

--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -110,7 +110,22 @@ function parseJsonField(
 	}
 }
 
-function parseEntityArray(val: unknown): Array<{ id: string }> {
+function tryParseJsonOrJs(str: string): any {
+	const trimmed = str.trim();
+	try {
+		return JSON.parse(trimmed);
+	} catch (_) {}
+
+	try {
+		// Repair single quotes and unquoted keys (e.g., [{ id: 'medium' }] -> [{"id": "medium"}])
+		const repaired = trimmed.replace(/'/g, '"').replace(/([{,]\s*)([a-zA-Z0-9_]+)\s*:/g, '$1"$2":');
+		return JSON.parse(repaired);
+	} catch (_) {}
+
+	return null;
+}
+
+function parseEntityArray(val: unknown): Array<{ id: string; name?: string; color?: string }> {
 	if (!val) {
 		return [];
 	}
@@ -122,25 +137,33 @@ function parseEntityArray(val: unknown): Array<{ id: string }> {
 					return { id: item.trim() };
 				}
 				if (item && typeof item === 'object') {
-					const id = (item as { id?: unknown })?.id;
-					if (typeof id === 'string') {
-						return { id: id.trim() };
+					const obj = item as Record<string, unknown>;
+					const id = obj.id;
+					if (typeof id === 'string' || typeof id === 'number') {
+						const name = typeof obj.name === 'string' ? obj.name : undefined;
+						const color = typeof obj.color === 'string' ? obj.color : undefined;
+						return {
+							id: String(id).trim(),
+							...(name ? { name } : {}),
+							...(color ? { color } : {}),
+						};
 					}
 				}
 				return null;
 			})
-			.filter((x): x is { id: string } => x !== null && !!x.id);
+			.filter((x): x is { id: string; name?: string; color?: string } => x !== null && !!x.id);
 	}
 
 	if (typeof val === 'string') {
 		const trimmed = val.trim();
-		if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
-			try {
-				const parsed = JSON.parse(trimmed);
-				if (Array.isArray(parsed)) {
-					return parseEntityArray(parsed);
-				}
-			} catch (_) {}
+		if (
+			(trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+			(trimmed.startsWith('{') && trimmed.endsWith('}'))
+		) {
+			const parsed = tryParseJsonOrJs(trimmed);
+			if (parsed) {
+				return parseEntityArray(parsed);
+			}
 		}
 
 		return trimmed
@@ -148,6 +171,23 @@ function parseEntityArray(val: unknown): Array<{ id: string }> {
 			.map((id) => id.trim())
 			.filter(Boolean)
 			.map((id) => ({ id }));
+	}
+
+	if (typeof val === 'object') {
+		const obj = val as Record<string, unknown>;
+		if (obj.label !== undefined) {
+			return parseEntityArray(obj.label);
+		}
+		if (obj.entity !== undefined) {
+			return parseEntityArray(obj.entity);
+		}
+		if (obj.id !== undefined && (typeof obj.id === 'string' || typeof obj.id === 'number')) {
+			const name = typeof obj.name === 'string' ? obj.name : undefined;
+			const color = typeof obj.color === 'string' ? obj.color : undefined;
+			return [
+				{ id: String(obj.id).trim(), ...(name ? { name } : {}), ...(color ? { color } : {}) },
+			];
+		}
 	}
 
 	return [];
@@ -307,9 +347,14 @@ function mapUiPropertyToApi(prop: { id: string; type: string; value: unknown }):
 	} else if (type === 'date') {
 		return parseDateProperty(val);
 	} else if (type === 'label') {
+		const parsed = parseEntityArray(val);
 		return {
 			type: 'label',
-			label: parseEntityArray(val),
+			label: parsed.map((item) => ({
+				id: item.id,
+				name: item.name ?? item.id,
+				...(item.color ? { color: item.color } : {}),
+			})),
 		};
 	} else if (type === 'entity') {
 		return {

--- a/nodes/Capacities/V2/ObjectDescription.ts
+++ b/nodes/Capacities/V2/ObjectDescription.ts
@@ -185,7 +185,7 @@ export const object: INodeProperties[] = [
 								type: 'string',
 								default: '',
 								description:
-									'The value to set (use true/false for Boolean, numbers for Number, ISO strings, ranges like "2026-08-13 to 2026-08-15", or JSON/expressions for Date)',
+									'The value to set (use true/false for Boolean, numbers for Number, ISO strings/ranges for Date, or comma-separated IDs / JSON objects/arrays for Label and Reference properties)',
 							},
 						],
 					},
@@ -276,7 +276,7 @@ export const object: INodeProperties[] = [
 								type: 'string',
 								default: '',
 								description:
-									'The value to set (use true/false for Boolean, numbers for Number, ISO strings, ranges like "2026-08-13 to 2026-08-15", or JSON/expressions for Date)',
+									'The value to set (use true/false for Boolean, numbers for Number, ISO strings/ranges for Date, or comma-separated IDs / JSON objects/arrays for Label and Reference properties)',
 							},
 						],
 					},

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -365,7 +365,13 @@ describe('CapacitiesV2 node', () => {
 					type: 'date',
 					date: { dateResolution: 'day', start: '2026-08-13T00:00:00.000Z', end: null },
 				},
-				tags: { type: 'label', label: [{ id: 'tag-1' }, { id: 'tag-2' }] },
+				tags: {
+					type: 'label',
+					label: [
+						{ id: 'tag-1', name: 'tag-1' },
+						{ id: 'tag-2', name: 'tag-2' },
+					],
+				},
 				links: { type: 'entity', entity: [{ id: 'ent-1' }, { id: 'ent-2' }] },
 			},
 		});
@@ -406,9 +412,101 @@ describe('CapacitiesV2 node', () => {
 			structureId: 'structure-1',
 			properties: {
 				title: { type: 'title', title: { value: 'My Object' } },
-				tags1: { type: 'label', label: [{ id: 'tag-1' }, { id: 'tag-2' }] },
-				tags2: { type: 'label', label: [{ id: 'tag-3' }, { id: 'tag-4' }] },
-				tags3: { type: 'label', label: [{ id: 'tag-5' }, { id: 'tag-6' }] },
+				tags1: {
+					type: 'label',
+					label: [
+						{ id: 'tag-1', name: 'tag-1' },
+						{ id: 'tag-2', name: 'tag-2' },
+					],
+				},
+				tags2: {
+					type: 'label',
+					label: [
+						{ id: 'tag-3', name: 'tag-3' },
+						{ id: 'tag-4', name: 'tag-4' },
+					],
+				},
+				tags3: {
+					type: 'label',
+					label: [
+						{ id: 'tag-5', name: 'tag-5' },
+						{ id: 'tag-6', name: 'tag-6' },
+					],
+				},
+			},
+		});
+	});
+
+	it('handles single objects, nested properties, and stringified JSON objects for label/entity properties', async () => {
+		const node = new CapacitiesV2();
+		mockObjectCreate.mockResolvedValue({ id: 'created-object' });
+
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'create',
+					structureId: 'structure-1',
+					title: 'My Object',
+					additionalFields: {
+						propertiesToSend: {
+							property: [
+								{ id: 'single_obj', type: 'label', value: { id: 'tag-1', name: 'Tag 1' } },
+								{ id: 'single_obj_str', type: 'label', value: '{"id": "tag-2", "name": "Tag 2"}' },
+								{
+									id: 'nested_label_obj',
+									type: 'label',
+									value: { type: 'label', label: [{ id: 'tag-3' }] },
+								},
+								{
+									id: 'nested_label_str',
+									type: 'label',
+									value: '{"type": "label", "label": [{"id": "tag-4"}]}',
+								},
+								{
+									id: 'nested_entity_obj',
+									type: 'entity',
+									value: { type: 'entity', entity: [{ id: 'ent-1' }] },
+								},
+								{
+									id: 'nested_entity_str',
+									type: 'entity',
+									value: '{"type": "entity", "entity": [{"id": "ent-2"}]}',
+								},
+								{ id: 'single_quoted_obj_arr', type: 'label', value: "[{ id: 'medium' }]" },
+								{ id: 'single_quoted_str_arr', type: 'label', value: "['tag-1', 'tag-2']" },
+							],
+						},
+					},
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		await node.execute.call(context);
+
+		expect(mockObjectCreate).toHaveBeenCalledWith({
+			structureId: 'structure-1',
+			properties: {
+				title: { type: 'title', title: { value: 'My Object' } },
+				single_obj: { type: 'label', label: [{ id: 'tag-1', name: 'Tag 1' }] },
+				single_obj_str: { type: 'label', label: [{ id: 'tag-2', name: 'Tag 2' }] },
+				nested_label_obj: { type: 'label', label: [{ id: 'tag-3', name: 'tag-3' }] },
+				nested_label_str: { type: 'label', label: [{ id: 'tag-4', name: 'tag-4' }] },
+				nested_entity_obj: { type: 'entity', entity: [{ id: 'ent-1' }] },
+				nested_entity_str: { type: 'entity', entity: [{ id: 'ent-2' }] },
+				single_quoted_obj_arr: { type: 'label', label: [{ id: 'medium', name: 'medium' }] },
+				single_quoted_str_arr: {
+					type: 'label',
+					label: [
+						{ id: 'tag-1', name: 'tag-1' },
+						{ id: 'tag-2', name: 'tag-2' },
+					],
+				},
 			},
 		});
 	});


### PR DESCRIPTION
## Summary
This PR optimizes the saving and parsing of label and entity property values in the Capacities V2 node. It addresses two main usability/correctness issues:
1. **SDK Zod Validation Error**: Preserves optional `name` and `color` properties on parsed label values, and defaults `name` to the `id` value if omitted, satisfying the `@capacities/api` SDK's Zod schema validation checks.
2. **Robust JS-like Parsing**: Implemented a parser fallback (`tryParseJsonOrJs`) that pre-repairs single quotes and unquoted object keys (e.g., `[{ id: 'medium' }]` -> `[{"id": "medium"}]`) before parsing them as standard JSON, preventing them from falling back to literal string IDs.

Additionally:
- Updated the inline help description of the `value` field in `ObjectDescription.ts` to document formats for Label and Reference properties.
- Added comprehensive unit tests in `CapacitiesV2.node.test.ts` to cover all of these new formats.
- Documented these mapping formats and added a complete Task creation example in `README.md`.

## Verification & Build
- Rebuilt successfully via `pnpm build`. Note that `dist/` is gitignored and compiled bundles will be handled post-merge/during release.
- Passed ESLint and Prettier check (`pnpm lint`, `pnpm format`).
- All 70 Jest unit tests passed successfully (`pnpm test`).