### PR TITLE
Add markdown-based create/update/append operations for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ pnpm add @muench-dev/n8n-nodes-capacities
 	- Save tags as `RootTag` objects for later use in object tag properties
 - Object operations
 	- Create an object of any structure/type, with a title plus optional additional properties, collections, and block content
+	- Create an object directly from Markdown body content (`POST /object/markdown`)
+	- Append Markdown content to an existing object's body (block-append endpoint)
+	- Update From Markdown Frontmatter: update an object's properties from a YAML frontmatter block in a Markdown string, without touching its body content (`PATCH /object/markdown`) — see [Updating Properties From Markdown Frontmatter](#updating-properties-from-markdown-frontmatter) below
 - Daily note operations
 	- Append markdown to a daily note, optionally skipping the automatic timestamp or targeting a specific date
 
@@ -94,6 +97,27 @@ Alternatively, you can define all properties using **Properties (JSON)**:
   }
 }
 ```
+
+## Updating Properties From Markdown Frontmatter
+
+The **Update From Markdown Frontmatter** object operation (`PATCH /object/markdown`) only ever reads the YAML frontmatter block of the **Markdown Frontmatter** field — it never touches the object's body content. It's a shortcut for setting a few plain-value properties without building the typed JSON properties structure used by **Properties (JSON)** / **Properties to Send**, and it works differently from **Create From Markdown** and **Append From Markdown**, which instead set/append actual body content:
+
+- The **Markdown Frontmatter** field must start with a YAML frontmatter block delimited by `---` lines.
+- Each key in the frontmatter is a property ID — either a built-in one like `title`, or the UUID of a custom property (the same IDs used elsewhere in this node's Properties (JSON) / Properties to Send fields).
+- Each value is the plain value to set (a string, number, or boolean) — not the typed `{ type, ... }` wrapper the JSON-based property fields require.
+- Any content after the closing `---` is ignored, so this operation **cannot** change the object body — use Append From Markdown (to add content) or Create From Markdown (when creating) for that instead.
+- Omitted properties are left unchanged.
+
+Example — set the title and a custom `description` property on an existing object:
+
+1. **Object ID**: the ID of the object to update.
+2. **Markdown Frontmatter**:
+   ```
+   ---
+   title: New Title
+   description: Updated description
+   ---
+   ```
 
 ---
 

--- a/nodes/Capacities/V2/CapacitiesV2.node.ts
+++ b/nodes/Capacities/V2/CapacitiesV2.node.ts
@@ -555,6 +555,11 @@ export class CapacitiesV2 implements INodeType {
 							itemIndex,
 						) as any,
 					);
+				} else if (resource === 'object' && operation === 'createFromMarkdown') {
+					const structureId = this.getNodeParameter('structureId', itemIndex) as string;
+					const markdown = this.getNodeParameter('markdown', itemIndex) as string;
+
+					response = await client.object.markdown.create({ structureId, markdown });
 				} else if (resource === 'object' && operation === 'update') {
 					const id = this.getNodeParameter('id', itemIndex) as string;
 					const updateFields = this.getNodeParameter('updateFields', itemIndex, {}) as {
@@ -621,6 +626,16 @@ export class CapacitiesV2 implements INodeType {
 					}
 
 					response = await client.object.update(body);
+				} else if (resource === 'object' && operation === 'updateFromMarkdownFrontmatter') {
+					const id = this.getNodeParameter('id', itemIndex) as string;
+					const markdown = this.getNodeParameter('markdown', itemIndex) as string;
+
+					response = await client.object.markdown.update({ id, markdown });
+				} else if (resource === 'object' && operation === 'appendFromMarkdown') {
+					const id = this.getNodeParameter('id', itemIndex) as string;
+					const markdown = this.getNodeParameter('markdown', itemIndex) as string;
+
+					response = await client.blocks.append({ id, markdown });
 				} else if (resource === 'object' && operation === 'delete') {
 					const id = this.getNodeParameter('id', itemIndex) as string;
 					const hardDelete = this.getNodeParameter('hardDelete', itemIndex, false) as boolean;

--- a/nodes/Capacities/V2/ObjectDescription.ts
+++ b/nodes/Capacities/V2/ObjectDescription.ts
@@ -10,6 +10,12 @@ export const object: INodeProperties[] = [
 		default: 'create',
 		options: [
 			{
+				name: 'Append From Markdown',
+				value: 'appendFromMarkdown',
+				description: "Append Markdown content to an existing object's body",
+				action: 'Append markdown to an object',
+			},
+			{
 				name: 'Create',
 				value: 'create',
 				description: 'Create an object of any structure/type',
@@ -32,6 +38,12 @@ export const object: INodeProperties[] = [
 				},
 			},
 			{
+				name: 'Create From Markdown',
+				value: 'createFromMarkdown',
+				description: 'Create an object from Markdown content',
+				action: 'Create an object from markdown',
+			},
+			{
 				name: 'Delete',
 				value: 'delete',
 				description: 'Delete an object from your space',
@@ -48,6 +60,13 @@ export const object: INodeProperties[] = [
 				value: 'update',
 				description: 'Update properties, collections, or blocks of an object',
 				action: 'Update an object',
+			},
+			{
+				name: 'Update From Markdown Frontmatter',
+				value: 'updateFromMarkdownFrontmatter',
+				description:
+					"Update object properties from a YAML frontmatter block in a Markdown string (the object's body content is not touched)",
+				action: 'Update an object from markdown frontmatter',
 			},
 		],
 		displayOptions: {
@@ -70,7 +89,7 @@ export const object: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['object'],
-				operation: ['create'],
+				operation: ['create', 'createFromMarkdown'],
 			},
 		},
 	},
@@ -89,6 +108,38 @@ export const object: INodeProperties[] = [
 		},
 	},
 	{
+		displayName: 'Markdown',
+		name: 'markdown',
+		type: 'string',
+		default: '',
+		required: true,
+		description:
+			'The Markdown body content to set (Create) or append (Append). See the <a href="https://developers.capacities.io/api/concepts/markdown">Capacities markdown docs</a> for supported syntax.',
+		hint: 'Plain Markdown, e.g. "## Heading\\n\\nSome body text."',
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['createFromMarkdown', 'appendFromMarkdown'],
+			},
+		},
+	},
+	{
+		displayName: 'Markdown Frontmatter',
+		name: 'markdown',
+		type: 'string',
+		default: '',
+		required: true,
+		description:
+			'Only the YAML frontmatter block is processed - keys are property IDs (e.g. "title", or a UUID for custom properties) and values are the new plain values to set. Everything after the closing "---" is ignored, so this cannot be used to change the object body - use the Create From Markdown or Append From Markdown operations for that.',
+		hint: 'Example: "---\\ntitle: New Title\\ndescription: Updated description\\n---"',
+		displayOptions: {
+			show: {
+				resource: ['object'],
+				operation: ['updateFromMarkdownFrontmatter'],
+			},
+		},
+	},
+	{
 		displayName: 'Object ID',
 		name: 'id',
 		type: 'string',
@@ -98,7 +149,13 @@ export const object: INodeProperties[] = [
 		displayOptions: {
 			show: {
 				resource: ['object'],
-				operation: ['get', 'update', 'delete'],
+				operation: [
+					'get',
+					'update',
+					'delete',
+					'updateFromMarkdownFrontmatter',
+					'appendFromMarkdown',
+				],
 			},
 		},
 	},

--- a/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
+++ b/nodes/Capacities/V2/__tests__/CapacitiesV2.node.test.ts
@@ -11,7 +11,10 @@ const mockObjectCreate = jest.fn();
 const mockObjectUpdate = jest.fn();
 const mockObjectDelete = jest.fn();
 const mockObjectCreateFromUrl = jest.fn();
+const mockObjectMarkdownCreate = jest.fn();
+const mockObjectMarkdownUpdate = jest.fn();
 const mockBlocksDailyNoteAppend = jest.fn();
+const mockBlocksAppend = jest.fn();
 
 jest.mock('@capacities/api', () => {
 	return {
@@ -30,11 +33,16 @@ jest.mock('@capacities/api', () => {
 					update: mockObjectUpdate,
 					delete: mockObjectDelete,
 					createFromUrl: mockObjectCreateFromUrl,
+					markdown: {
+						create: mockObjectMarkdownCreate,
+						update: mockObjectMarkdownUpdate,
+					},
 				},
 				blocks: {
 					dailyNote: {
 						append: mockBlocksDailyNoteAppend,
 					},
+					append: mockBlocksAppend,
 				},
 			};
 		}),
@@ -146,6 +154,34 @@ describe('CapacitiesV2 node', () => {
 			},
 		});
 		expect(result).toEqual([[{ json: { id: 'created-object' } }]]);
+	});
+
+	it('creates objects from markdown', async () => {
+		const node = new CapacitiesV2();
+		mockObjectMarkdownCreate.mockResolvedValue({ id: 'created-object-md' });
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'createFromMarkdown',
+					structureId: 'structure-1',
+					markdown: '# My Object\n\nSome body text.',
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		const result = await node.execute.call(context);
+
+		expect(mockObjectMarkdownCreate).toHaveBeenCalledWith({
+			structureId: 'structure-1',
+			markdown: '# My Object\n\nSome body text.',
+		});
+		expect(result).toEqual([[{ json: { id: 'created-object-md' } }]]);
 	});
 
 	it('creates objects with additional properties, collections, and blocks', async () => {
@@ -288,6 +324,62 @@ describe('CapacitiesV2 node', () => {
 			},
 		});
 		expect(result).toEqual([[{ json: { id: 'updated-object' } }]]);
+	});
+
+	it('updates objects from markdown', async () => {
+		const node = new CapacitiesV2();
+		mockObjectMarkdownUpdate.mockResolvedValue({ id: 'updated-object-md' });
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'updateFromMarkdownFrontmatter',
+					id: 'object-id-123',
+					markdown: '---\ntitle: Updated Title\n---\n',
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		const result = await node.execute.call(context);
+
+		expect(mockObjectMarkdownUpdate).toHaveBeenCalledWith({
+			id: 'object-id-123',
+			markdown: '---\ntitle: Updated Title\n---\n',
+		});
+		expect(result).toEqual([[{ json: { id: 'updated-object-md' } }]]);
+	});
+
+	it('appends markdown to objects', async () => {
+		const node = new CapacitiesV2();
+		mockBlocksAppend.mockResolvedValue({ id: 'appended-object-md' });
+		const context = {
+			getInputData: jest.fn(() => [{ json: {} }]),
+			getNode: jest.fn(() => ({ name: 'Capacities', type: 'capacities' })),
+			getNodeParameter: jest.fn((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					resource: 'object',
+					operation: 'appendFromMarkdown',
+					id: 'object-id-123',
+					markdown: '## Appended\n\nMore body text.',
+				};
+
+				return parameters[parameterName];
+			}),
+			getCredentials: jest.fn(() => Promise.resolve({ token: 'test-token' })),
+		} as unknown as IExecuteFunctions;
+
+		const result = await node.execute.call(context);
+
+		expect(mockBlocksAppend).toHaveBeenCalledWith({
+			id: 'object-id-123',
+			markdown: '## Appended\n\nMore body text.',
+		});
+		expect(result).toEqual([[{ json: { id: 'appended-object-md' } }]]);
 	});
 
 	it('deletes objects', async () => {

--- a/nodes/Capacities/V2/__tests__/ObjectDescription.test.ts
+++ b/nodes/Capacities/V2/__tests__/ObjectDescription.test.ts
@@ -30,6 +30,95 @@ describe('Object description (v2)', () => {
 		});
 	});
 
+	it('defines createFromMarkdown object operation', () => {
+		const operationProperty = getProperty(object, 'operation', 'object');
+		expect(operationProperty).toBeDefined();
+		const option = getOptions(operationProperty).find(
+			(option) => option.value === 'createFromMarkdown',
+		);
+		expect(option).toMatchObject({
+			name: 'Create From Markdown',
+			value: 'createFromMarkdown',
+			description: 'Create an object from Markdown content',
+			action: 'Create an object from markdown',
+		});
+	});
+
+	it('exposes a body-content markdown field for the createFromMarkdown and appendFromMarkdown operations', () => {
+		const markdownProperties = object.filter((property) => property.name === 'markdown');
+		const bodyMarkdownProperty = markdownProperties.find(
+			(property) =>
+				property.displayOptions?.show?.operation &&
+				Array.isArray(property.displayOptions.show.operation) &&
+				property.displayOptions.show.operation.includes('createFromMarkdown'),
+		);
+
+		expect(bodyMarkdownProperty).toMatchObject({
+			type: 'string',
+			required: true,
+			default: '',
+			displayOptions: {
+				show: {
+					resource: ['object'],
+					operation: ['createFromMarkdown', 'appendFromMarkdown'],
+				},
+			},
+		});
+	});
+
+	it('exposes a frontmatter markdown field for the updateFromMarkdownFrontmatter operation', () => {
+		const markdownProperties = object.filter((property) => property.name === 'markdown');
+		const frontmatterMarkdownProperty = markdownProperties.find(
+			(property) =>
+				property.displayOptions?.show?.operation &&
+				Array.isArray(property.displayOptions.show.operation) &&
+				property.displayOptions.show.operation.includes('updateFromMarkdownFrontmatter'),
+		);
+
+		expect(frontmatterMarkdownProperty).toMatchObject({
+			displayName: 'Markdown Frontmatter',
+			type: 'string',
+			required: true,
+			default: '',
+			displayOptions: {
+				show: {
+					resource: ['object'],
+					operation: ['updateFromMarkdownFrontmatter'],
+				},
+			},
+		});
+		expect(frontmatterMarkdownProperty?.description).toContain('YAML frontmatter');
+	});
+
+	it('defines appendFromMarkdown object operation', () => {
+		const operationProperty = getProperty(object, 'operation', 'object');
+		expect(operationProperty).toBeDefined();
+		const option = getOptions(operationProperty).find(
+			(option) => option.value === 'appendFromMarkdown',
+		);
+		expect(option).toMatchObject({
+			name: 'Append From Markdown',
+			value: 'appendFromMarkdown',
+			description: "Append Markdown content to an existing object's body",
+			action: 'Append markdown to an object',
+		});
+	});
+
+	it('defines updateFromMarkdownFrontmatter object operation', () => {
+		const operationProperty = getProperty(object, 'operation', 'object');
+		expect(operationProperty).toBeDefined();
+		const option = getOptions(operationProperty).find(
+			(option) => option.value === 'updateFromMarkdownFrontmatter',
+		);
+		expect(option).toMatchObject({
+			name: 'Update From Markdown Frontmatter',
+			value: 'updateFromMarkdownFrontmatter',
+			description:
+				"Update object properties from a YAML frontmatter block in a Markdown string (the object's body content is not touched)",
+			action: 'Update an object from markdown frontmatter',
+		});
+	});
+
 	it('exposes a required title field', () => {
 		const titleProperty = getProperty(object, 'title', 'object');
 
@@ -92,7 +181,13 @@ describe('Object description (v2)', () => {
 			displayOptions: {
 				show: {
 					resource: ['object'],
-					operation: ['get', 'update', 'delete'],
+					operation: [
+					'get',
+					'update',
+					'delete',
+					'updateFromMarkdownFrontmatter',
+					'appendFromMarkdown',
+				],
 				},
 			},
 		});


### PR DESCRIPTION
## Summary
- Add **Create From Markdown** object operation (`POST /object/markdown`) to create objects directly from Markdown body content.
- Add **Append From Markdown** object operation (blocks append endpoint) to append Markdown content to an existing object's body.
- Add **Update From Markdown Frontmatter** object operation (`PATCH /object/markdown`) to update object properties from a YAML frontmatter block — the label and field name make explicit that only the frontmatter is processed and the body content is never touched.

## Test plan
- [x] `pnpm jest` — 78 tests passing
- [x] `pnpm build` — typecheck + asset copy succeed
- [x] `pnpm lint` — no issues found